### PR TITLE
setup.py: re-version, and set minimum pecan version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='',
     author_email='',
     install_requires=[
-        'pecan',
+        'pecan>=1',
         'celery',
         'sqlalchemy',
         'gunicorn',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name='ceph-installer',
-    version='0.1',
+    version='0.2.0',
     description='An HTTP API that provides Ceph installation/configuration endpoints',
     author='',
     author_email='',


### PR DESCRIPTION
The first commit corrects the version field to reflect the latest git tag.  

The third commit sets a minimum version requirement for pecan.  I am getting test failures with the v0.4.5 pecan package in EPEL 7, so I'm picking "1" here just because it's generally more modern, and RHEL OSP already has RHEL packages for v1.0.2.