### PR TITLE
README: note that wget ... | sudo bash is insecure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,12 @@ it is implemented with the ``"callback"`` key in most JSON POST requests.
 
     wget http://installer.host/setup/ | sudo bash
 
+**Security**: the above example retrieves executable code over an
+unencrypted protocol and then executes it as root.  You should only
+use this approach if you 100% trust your network and your DNS
+server.
+
+
 2.- Install monitor:
 
 request::


### PR DESCRIPTION
I noticed that this new installer is recommending that people use a "wget http:// ... | sudo bash" approach to installing code on their systems.  This should always come with a loud health warning: anyone with access to the IP network in use can potentially subvert this.