### PR TITLE
add HOME to the env section in circus.ini

### DIFF
--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -25,3 +25,4 @@ stderr_stream.filename=/var/log/circus/celery-stderr.log
 [env:celery,{{ app_name }}]
 PECAN_CONFIG = {{ app_home }}/src/{{ app_name }}/config/config.py
 CEPH_ANSIBLE_PATH = {{ app_home }}/ceph-ansible
+HOME = /home/{{ ansible_ssh_user }}


### PR DESCRIPTION
We need this because circus is wiping the environment and ansible
depends on $HOME being set.

See: https://github.com/ceph/ceph-installer/issues/58

Signed-off-by: Andrew Schoen <aschoen@redhat.com>