### PR TITLE
listen on all addresses on production

### DIFF
--- a/config/prod.py
+++ b/config/prod.py
@@ -3,7 +3,7 @@ from ceph_installer import hooks
 # Server Specific Configurations
 server = {
     'port': '8181',
-    'host': 'localhost'
+    'host': '0.0.0.0'
 }
 
 # Pecan Application Configurations


### PR DESCRIPTION
Because this app is required to make certain flags available to the rest of the
network. If by default it binds to localhost these endpoints (mainly: /setup/
and /setup/agent/) will not be able to service other nodes.

Signed-off-by: Alfredo Deza <adeza@redhat.com>