### PR TITLE
import systemd unit files

### DIFF
--- a/systemd/80-ceph-installer.preset
+++ b/systemd/80-ceph-installer.preset
@@ -1,0 +1,3 @@
+# ceph-installer web service
+
+enable ceph-installer.service

--- a/systemd/ceph-installer-celery.service
+++ b/systemd/ceph-installer-celery.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ceph installer celery service
+After=network.target rabbitmq-server.service
+Requires=rabbitmq-server.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/celery -A async worker --loglevel=info
+EnvironmentFile=-/etc/sysconfig/ceph-installer
+User=ceph-installer
+WorkingDirectory=/usr/lib/python2.7/site-packages/ceph_installer
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ceph-installer.service
+++ b/systemd/ceph-installer.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ceph installer gunicorn service
+After=network.target ceph-installer-celery.service
+Requires=ceph-installer-celery.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/gunicorn_pecan -w 10 -t 300 /etc/ceph-installer/prod.py
+EnvironmentFile=-/etc/sysconfig/ceph-installer
+User=ceph-installer
+WorkingDirectory=/usr/lib/python2.7/site-packages/ceph_installer/
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ceph-installer.sysconfig
+++ b/systemd/ceph-installer.sysconfig
@@ -1,0 +1,2 @@
+PECAN_CONFIG = /etc/ceph-installer/prod.py
+CEPH_PLAYBOOK = /usr/share/ceph-ansible/site.yml.sample


### PR DESCRIPTION
These are the files I'm using the RPM packaging. They will need some
work to become more generalized.

The files are installed to the following locations on RHEL 7:

    /etc/sysconfig/ceph-installer
    /usr/lib/systemd/system-preset/80-ceph-installer.preset
    /usr/lib/systemd/system/ceph-installer-celery.service
    /usr/lib/systemd/system/ceph-installer.service