### PR TITLE
require that osd/configure take a list of monitors like mon/configure

### DIFF
--- a/ceph_installer/controllers/osd.py
+++ b/ceph_installer/controllers/osd.py
@@ -54,12 +54,13 @@ class OSDController(object):
     @validate(schemas.osd_configure_schema, handler="/errors/schema")
     def configure_post(self):
         hosts = [request.json['host']]
-        monitor_hosts = request.json["monitor_hosts"]
+        monitor_hosts = util.parse_monitors(request.json["monitors"])
         # even with configuring we need to tell ceph-ansible
         # if we're working with upstream ceph or red hat ceph storage
         extra_vars = util.get_install_extra_vars(request.json)
         extra_vars.update(request.json)
         del extra_vars['host']
+        del extra_vars['monitors']
         if 'redhat_storage' in request.json:
             del extra_vars['redhat_storage']
         identifier = str(uuid4())

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -42,8 +42,7 @@ osd_configure_schema = (
     ("host", types.string),
     ("journal_collocation", types.boolean),
     ("journal_size", types.integer),
-    ("monitor_hosts", list_of_hosts),
-    ("monitor_interface", types.string),
+    ("monitors", list_of_monitors),
     ("public_network", types.string),
     (optional("redhat_storage"), types.boolean),
 )

--- a/ceph_installer/tests/controllers/test_osd.py
+++ b/ceph_installer/tests/controllers/test_osd.py
@@ -6,10 +6,9 @@ class TestOSDController(object):
     def setup(self):
         data = dict(
             host="node1",
-            monitor_interface="eth0",
             fsid="1720107309134",
             devices=['/dev/sdb'],
-            monitor_hosts=["mon.host"],
+            monitors=[{"host": "mon1.host", "interface": "eth1"}],
             journal_collocation=True,
             journal_size=100,
             public_network="0.0.0.0/24",
@@ -60,7 +59,7 @@ class TestOSDController(object):
     def test_configure_monitor_hosts(self, session, monkeypatch):
         def check(args, kwargs):
             inventory = args[0]
-            assert "mon.host" in inventory[1][1]
+            assert "mon1.host monitor_interface=eth1" in inventory[1][1]
 
         monkeypatch.setattr(osd.call_ansible, 'apply_async', check)
         result = session.app.post_json("/api/osd/configure/", params=self.configure_data)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -394,7 +394,7 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
           "public_network": "0.0.0.0/0",
           "cluster_network": "0.0.0.0/0",
           "redhat_storage": false,
-          "monitor_hosts": ["mon1.host", "mon2.host"],
+          "monitors": [{"host": "mon0.host", "interface": "eth1"}],
       }
 
    :<json array devices: (required) The devices to use for OSDs
@@ -405,7 +405,8 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
    :<json string cluster_network: (required) The cluster-only network
    :<json boolean redhat_storage: (optional) Use the downstream version of
                                   RedHat Storage.
-   :<json array monitor_hosts: (required) The monitors for the current cluster
+   :<json array monitors: (required) The monitors for the cluster you want to add this OSD to.
+                          Provide a list of objects representing the monitor host and its interface.
 
 
 ``rgw``


### PR DESCRIPTION
This allows an OSD to be added to an existing cluster that has multiple
mons with potentially different interfaces between them.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>