### PR TITLE
cluster_network defaults to public_network, make it optional

### DIFF
--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -25,7 +25,7 @@ install_schema = (
 )
 
 mon_configure_schema = (
-    ("cluster_network", types.string),
+    (optional("cluster_network"), types.string),
     ("fsid", types.string),
     ("host", types.string),
     ("monitor_interface", types.string),
@@ -36,7 +36,7 @@ mon_configure_schema = (
 )
 
 osd_configure_schema = (
-    ("cluster_network", types.string),
+    (optional("cluster_network"), types.string),
     ("devices", list_of_devices),
     ("fsid", types.string),
     ("host", types.string),

--- a/ceph_installer/tests/controllers/test_mon.py
+++ b/ceph_installer/tests/controllers/test_mon.py
@@ -6,7 +6,6 @@ class TestMonController(object):
     def setup(self):
         self.configure_data = dict(
             monitor_secret="secret",
-            cluster_network="0.0.0.0/24",
             public_network="0.0.0.0/24",
             host="node1",
             monitor_interface="eth0",

--- a/ceph_installer/tests/controllers/test_osd.py
+++ b/ceph_installer/tests/controllers/test_osd.py
@@ -12,7 +12,6 @@ class TestOSDController(object):
             journal_collocation=True,
             journal_size=100,
             public_network="0.0.0.0/24",
-            cluster_network="0.0.0.0/24",
         )
         self.configure_data = data
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -322,8 +322,8 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
    :<json string host: (required) The hostname to configure
    :<json string monitor_interface: (required) The interface name (e.g. "eth0")
    :<json string monitor_secret: (required) A key to use when creating the monitor keyrings.
-   :<json string cluster_network: (required) The subnet that the cluster will listen on.
-   :<json string public_network: (required) The public subnet that the cluster will reside on.
+   :<json string public_network: (required) The public network for the cluster.
+   :<json string cluster_network: (optional) If not provided, this will default to ``public_network``.
    :<json array monitors: (optional) This is only optional when no other monitors currently exist
                           in the cluster. If you're configuring a mon for an existing cluster, provide
                           a list of objects representing the monitor host and its interface.
@@ -402,7 +402,7 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
    :<json string host: (required) The hostname to configure
    :<json int journal_size: (required) The size to use for the journal
    :<json string public_network: (required) The public network for the cluster
-   :<json string cluster_network: (required) The cluster-only network
+   :<json string cluster_network: (optional) If not provided, this will default to ``public_network``.
    :<json boolean redhat_storage: (optional) Use the downstream version of
                                   RedHat Storage.
    :<json array monitors: (required) The monitors for the cluster you want to add this OSD to.


### PR DESCRIPTION
In ceph-ansible cluster_network defaults to the value given for
public_network so we don't need to require this field anymore.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>