### PR TITLE
Leaner system checks

### DIFF
--- a/ceph_installer/controllers/root.py
+++ b/ceph_installer/controllers/root.py
@@ -1,6 +1,7 @@
 from pecan import expose
 from ceph_installer.controllers import (
-    tasks, mon, osd, rgw, calamari, errors, setup, agent
+    tasks, mon, osd, rgw, calamari, errors, setup, agent,
+    status
 )
 
 
@@ -18,6 +19,7 @@ class ApiController(object):
     osd = osd.OSDController()
     rgw = rgw.RGWController()
     calamari = calamari.CalamariController()
+    status = status.StatusController()
 
 
 class RootController(object):

--- a/ceph_installer/controllers/status.py
+++ b/ceph_installer/controllers/status.py
@@ -1,0 +1,15 @@
+from pecan import response, expose
+from ceph_installer.hooks import system_checks, SystemCheckError
+
+
+class StatusController(object):
+
+    @expose('json')
+    def index(self):
+        for check in system_checks:
+            try:
+                check()
+            except SystemCheckError as system_error:
+                response.status = 500
+                return {'message': system_error.message}
+        return dict(message="ok")

--- a/ceph_installer/hooks.py
+++ b/ceph_installer/hooks.py
@@ -66,35 +66,34 @@ def database_connection():
             "Could not connect or retrieve information from the database: %s" % exc.message)
 
 
-class SystemCheckHook(PecanHook):
-    """
-    Perform a series of system checks which prevents the service from doing any
-    work unless everything required checks out.
-    """
-
-    def before(self, state):
-        """
-        Executed before a controller gets called. When an error condition is
-        detected (one of the callables raises a ``SystemCheckError``) it sets
-        the response status to 500 and returns a JSON response with the
-        appropriate reason.
-        """
-        for check in [ansible_exists, rabbitmq_is_running, celery_has_workers,
-                      database_connection]:
-            try:
-                check()
-            except SystemCheckError as system_error:
-                message = render('json', {'message': system_error.message})
-                raise WSGIHTTPException(content_type='application/json', body=message)
+system_checks = (
+    ansible_exists,
+    rabbitmq_is_running,
+    celery_has_workers,
+    database_connection
+)
 
 
 class CustomErrorHook(PecanHook):
     """
-    Only needed for prod environments where it looks like multi-worker servers
-    will swallow exceptions. This will ensure a traceback is logged correctly.
+    Ensure a traceback is logged correctly on error conditions.
+
+    When an error condition is detected (one of the callables raises
+    a ``SystemCheckError``) it sets the response status to 500 and returns
+    a JSON response with the appropriate reason.
     """
 
     def on_error(self, state, exc):
-        # TODO: do not complain with a traceback when the error is an
-        # HTTPNotFound
+        if isinstance(exc, WSGIHTTPException):
+            if exc.code == 404:
+                logger.error("Not Found: %s" % state.request.url)
+                return
         logger.exception('unhandled error by ceph-installer')
+        for check in system_checks:
+            try:
+                check()
+            except SystemCheckError as system_error:
+                state.response.json_body = {'message': system_error.message}
+                state.response.status = 500
+                state.response.content_type = 'application/json'
+                return state.response

--- a/ceph_installer/hooks.py
+++ b/ceph_installer/hooks.py
@@ -87,6 +87,11 @@ class CustomErrorHook(PecanHook):
             if exc.code == 404:
                 logger.error("Not Found: %s" % state.request.url)
                 return
+            # explicit redirect codes that should not be handled at all by this
+            # utility
+            elif exc.code in [300, 301, 302, 303, 304, 305, 306, 307, 308]:
+                return
+
         logger.exception('unhandled error by ceph-installer')
         for check in system_checks:
             try:

--- a/ceph_installer/hooks.py
+++ b/ceph_installer/hooks.py
@@ -2,7 +2,6 @@ from celery.task.control import inspect
 from errno import errorcode
 from ceph_installer import models
 from ceph_installer.util import which
-from pecan import render
 from pecan.hooks import PecanHook
 from sqlalchemy.exc import OperationalError
 from webob.exc import WSGIHTTPException

--- a/ceph_installer/tests/controllers/test_status.py
+++ b/ceph_installer/tests/controllers/test_status.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from uuid import uuid4
+
+from ceph_installer import hooks
+from ceph_installer.controllers import status
+
+
+def generic_system_error():
+    msg = "important system is not running"
+    raise hooks.SystemCheckError(msg)
+
+error_checks = (
+    generic_system_error,
+)
+
+ok_checks = (
+    lambda: True,
+)
+
+
+class TestSetupController(object):
+
+    def test_index_system_error_message(self, session, monkeypatch):
+        monkeypatch.setattr(status, 'system_checks', error_checks)
+        result = session.app.get("/api/status/", expect_errors=True)
+        assert result.json['message'] == 'important system is not running'
+
+    def test_index_system_error_code(self, session, monkeypatch):
+        monkeypatch.setattr(status, 'system_checks', error_checks)
+        result = session.app.get("/api/status/", expect_errors=True)
+        assert result.status_int == 500
+
+    def test_index_system_ok_message(self, session, monkeypatch):
+        monkeypatch.setattr(status, 'system_checks', ok_checks)
+        result = session.app.get("/api/status/")
+        assert result.json['message'] == "ok"
+
+    def test_index_system_ok_status(self, session, monkeypatch):
+        monkeypatch.setattr(status, 'system_checks', ok_checks)
+        result = session.app.get("/api/status/")
+        assert result.status_int == 200

--- a/ceph_installer/tests/controllers/test_status.py
+++ b/ceph_installer/tests/controllers/test_status.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-from uuid import uuid4
-
 from ceph_installer import hooks
 from ceph_installer.controllers import status
 

--- a/config/config.py
+++ b/config/config.py
@@ -11,7 +11,7 @@ app = {
     'root': 'ceph_installer.controllers.root.RootController',
     'modules': ['ceph_installer'],
     'debug': False,
-    'hooks': [hooks.SystemCheckHook(), hooks.CustomErrorHook()]
+    'hooks': [hooks.CustomErrorHook()]
 }
 
 logging = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -409,6 +409,25 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
                           Provide a list of objects representing the monitor host and its interface.
 
 
+``status``
+==========
+
+.. http:get:: /api/status/
+
+   Get the system status for the service. Performs checks against different
+   required systems and return an HTTP 500 error status code with a message.
+
+   **Response**:
+
+   .. sourcecode:: http
+
+     HTTP/1.1 500 Internal Server Error
+     Content-Type: application/json
+
+     {"message": "RabbitMQ is not running or not reachable"}
+
+  :statuscode 500: Server Error (see :ref:`server_errors`)
+
 .. _server_errors:
 
 Known Server Errors


### PR DESCRIPTION
This changes how the service has been using system checks. Before this, it would perform a series of system checks for every single request.

That is expensive and it would be potentially disruptive for a client that wants to fire multiple dozen requests at the same time.

The changes here will run the system checks when a controller method returns an error. There is a chance that the error does not map to an actual system error, in that case the exception is always logged and it is not handled by the system (unhandled error will just break the app, this is OK)