### PR TITLE
docs: fix another version number location instance

### DIFF
--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -13,7 +13,7 @@ When you are ready to cut a new version:
 #. Commit your setup.py change as "version 1.2.3".
    ::
 
-      git commit setup.py -m 'version 1.2.3'
+      git commit ceph_installer/__init__.py -m 'version 1.2.3'
 
 #. Tag and release to PyPI (known as "py-p-i" for you plebs).
    ::


### PR DESCRIPTION
The version number is no longer in setup.py. Stop instructing developers to commit changes to that file, and instruct users to commit `__init__.py` instead.