### PR TITLE
scan the remote host fingerprint

### DIFF
--- a/ceph_installer/controllers/setup.py
+++ b/ceph_installer/controllers/setup.py
@@ -54,10 +54,10 @@ class SetupController(object):
 
         # define the file to download
         response.headers['Content-Disposition'] = 'attachment; filename=id_rsa.pub'
-
         # finally, before serving the key, make sure that the host that is asking for
         # the key is added to the "known_hosts" file of the user running the service
-        command = ['ssh-keyscan', '-t', 'rsa', request.client_addr]
+        client = request.client_addr or request.environ['HTTP_REMOTE_ADDR']
+        command = ['ssh-keyscan', '-t', 'rsa', client]
         out, err, code = process.run(command)
         known_hosts_file = os.path.expanduser('~/.ssh/known_hosts')
         with open(known_hosts_file, 'a') as f:


### PR DESCRIPTION
So that it can be appended to `known_hosts` and prevent issues with ssh
complaining about the remote host being unknown and prompting for it when
Ansible wants to run in the background.

Signed-off-by: Alfredo Deza <adeza@redhat.com>