### PR TITLE
setup.py: require minimum notario version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'sqlalchemy',
         'gunicorn',
         'pecan-notario',
+        'notario>=0.0.11',
         'tambo',
     ],
     zip_safe=False,


### PR DESCRIPTION
Compared to notario v0.0.9, this v0.0.11 version contains data
validation fixes that we need.