### PR TITLE
lock the ansible version to 1.9.4

### DIFF
--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -51,6 +51,7 @@
   sudo: yes
   pip:
     name: ansible
+    version: 1.9.4
 
 - include: circus.yml
   tags:


### PR DESCRIPTION
I was seeing this issue in 2.0.0.2:

https://github.com/ansible/ansible/issues/13876

I do not see that in 1.9.4 though, so we'll pin the ansible version to
that for now.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>