### PR TITLE
prod.py: use CustomErrorHook()

### DIFF
--- a/config/prod.py
+++ b/config/prod.py
@@ -11,7 +11,7 @@ app = {
     'root': 'ceph_installer.controllers.root.RootController',
     'modules': ['ceph_installer'],
     'debug': False,
-    'hooks': [hooks.SystemCheckHook()]
+    'hooks': [hooks.CustomErrorHook()]
 }
 
 logging = {


### PR DESCRIPTION
Prior to this change, gunicorn fails to start, with the following error:

    gunicorn_pecan: Error: 'module' object has no attribute 'SystemCheckHook'

In 8b0e2fd38c267e61b515afb9c165260297020a9d, `config/config.py` was updated to use `CustomErrorHook()`. Do the same in `prod.py`.