### PR TITLE
create the `task` sub-command 

### DIFF
--- a/ceph-installer.spec
+++ b/ceph-installer.spec
@@ -21,6 +21,7 @@ Requires: python-pecan
 Requires: python-celery
 Requires: python-sqlalchemy
 Requires: python-gunicorn
+Requires: python-requests
 Requires: python-pecan-notario
 Requires: rabbitmq-server
 Requires(pre):    shadow-utils

--- a/ceph_installer/cli/constants.py
+++ b/ceph_installer/cli/constants.py
@@ -1,0 +1,2 @@
+
+server_address = 'http://localhost:8181/'

--- a/ceph_installer/cli/log.py
+++ b/ceph_installer/cli/log.py
@@ -19,3 +19,8 @@ def debug(message):
 def info(message):
     line = "%s %s\n" % (util.bold_arrow, message)
     sys.stdout.write(line)
+
+
+def warning(message):
+    line = "%s %s\n" % (util.yellow_arrow, message)
+    sys.stderr.write(line)

--- a/ceph_installer/cli/main.py
+++ b/ceph_installer/cli/main.py
@@ -3,7 +3,7 @@ import sys
 from tambo import Transport
 import ceph_installer
 from ceph_installer.cli import log
-from ceph_installer.cli import dev
+from ceph_installer.cli import dev, task
 from ceph_installer.cli.decorators import catches
 
 
@@ -23,7 +23,7 @@ Global Options:
 %s
     """
 
-    mapper = {'dev': dev.Dev}
+    mapper = {'dev': dev.Dev, 'task': task.Task}
 
     def __init__(self, argv=None, parse=True):
         self.plugin_help = "No plugins found/loaded"

--- a/ceph_installer/cli/main.py
+++ b/ceph_installer/cli/main.py
@@ -36,7 +36,7 @@ Global Options:
         version = ceph_installer.__version__
         return self._help % (version, subhelp)
 
-    @catches(KeyboardInterrupt, logger=log)
+    @catches(KeyboardInterrupt, handle_all=True, logger=log)
     def main(self, argv):
         parser = Transport(argv, mapper=self.mapper,
                            options=[], check_help=False,

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -31,6 +31,11 @@ class Task(object):
     --poll        Poll until the task has completed (either on failure or success)
     stdout        Retrieve the stdout output from the task
     stderr        Retrieve the stderr output from the task
+    command       The actual command used to call ansible
+    ended         The timestamp (in UTC) when the command completed
+    started       The timestamp (in UTC) when the command started
+    exit_code     The shell exit status for the process
+    succeeded     Boolean value to indicate if process completed correctly
     """)
 
     def __init__(self, arguments):

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -88,7 +88,7 @@ class Task(object):
                 time.sleep(0.3)
                 sys.stdout.flush()
             json = self.process_response(silent=True)
-        completed = json.get('ended', False)
+            completed = json.get('ended', False)
         sys.stdout.write('\r' + ' '*80)
         sys.stdout.flush()
         sys.stdout.write('\r'+'Task Completed!\n')

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -69,7 +69,8 @@ class Task(object):
         response = requests.get(self.request_url)
         json = response.json()
         if response.status_code >= 400:
-            log.error(json['message'])
+            if not silent:
+                log.error(json['message'])
             return {}
         return json
 

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -56,10 +56,11 @@ class Task(object):
         json = response.json()
         if response.status_code >= 400:
             return log.error(json['message'])
-        value = json.get(key)
-        if not value:
+        try:
+            value = json[key]
+            log.info("%s: %s" % (key, value))
+        except KeyError:
             return log.warning('no value found for: "%s"' % key)
-        log.info(value)
 
     def summary(self):
         response = requests.get(self.request_url)

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -73,8 +73,10 @@ class Task(object):
         return json
 
     def poll(self):
-        json = self.process_response()
-        completed = json['ended']
+        log.info('Polling task at: %s' % self.request_url)
+        json = self.process_response() or {}
+        # JSON could be set to None
+        completed = json.get('ended', False)
         while not completed:
             sequence = ['.', '..', '...', '....']
             for s in sequence:
@@ -83,8 +85,8 @@ class Task(object):
                 sys.stdout.write('\r' + string)
                 time.sleep(0.3)
                 sys.stdout.flush()
-            json = self.process_response()
-            completed = json['ended']
+            json = self.process_response() or {}
+        completed = json.get('ended', False)
         sys.stdout.write('\r' + ' '*80)
         sys.stdout.flush()
         sys.stdout.write('\r'+'Task Completed!\n')

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -5,18 +5,13 @@ import time
 from textwrap import dedent
 from tambo import Transport
 
-from ceph_installer import process
 from ceph_installer.cli import log, constants
-
-this_dir = path.abspath(path.dirname(__file__))
-top_dir = path.dirname(path.dirname(this_dir))
-playbook_path = path.join(top_dir, 'deploy/playbooks')
 
 
 class Task(object):
 
     help = "/api/tasks/ operations"
-    options = [] #['--poll', 'stdout', 'stderr']
+    options = []
     _help = dedent("""
     Human-readable task information: stdout, stderr, and the ability to "poll"
     a task that waits until the command completes to be able to show the output

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -65,16 +65,17 @@ class Task(object):
         for k, v in json.items():
             log.debug("%s: %s" % (k, v))
 
-    def process_response(self):
+    def process_response(self, silent=False):
         response = requests.get(self.request_url)
         json = response.json()
         if response.status_code >= 400:
-            return log.error(json['message'])
+            log.error(json['message'])
+            return {}
         return json
 
     def poll(self):
         log.info('Polling task at: %s' % self.request_url)
-        json = self.process_response() or {}
+        json = self.process_response()
         # JSON could be set to None
         completed = json.get('ended', False)
         while not completed:
@@ -85,7 +86,7 @@ class Task(object):
                 sys.stdout.write('\r' + string)
                 time.sleep(0.3)
                 sys.stdout.flush()
-            json = self.process_response() or {}
+            json = self.process_response(silent=True)
         completed = json.get('ended', False)
         sys.stdout.write('\r' + ' '*80)
         sys.stdout.flush()

--- a/ceph_installer/cli/task.py
+++ b/ceph_installer/cli/task.py
@@ -51,6 +51,7 @@ class Task(object):
         """
         :arg key: any actual key that can be present in the JSON output
         """
+        log.info('requesting task at: %s' % self.request_url)
         response = requests.get(self.request_url)
         json = response.json()
         if response.status_code >= 400:

--- a/ceph_installer/cli/util.py
+++ b/ceph_installer/cli/util.py
@@ -74,3 +74,4 @@ class colorize(str):
 red_arrow = colorize.make('-->').red
 blue_arrow = colorize.make('-->').blue
 bold_arrow = colorize.make('-->').bold
+yellow_arrow = colorize.make('-->').yellow

--- a/ceph_installer/controllers/tasks.py
+++ b/ceph_installer/controllers/tasks.py
@@ -9,7 +9,7 @@ class TaskController(object):
     def __init__(self, task_id):
         self.task = Task.query.filter_by(identifier=task_id).first()
         if not self.task:
-            error(404, '%s is not avilable' % task_id)
+            error(404, '%s is not available' % task_id)
 
     @expose('json')
     def index(self):

--- a/config/config.py
+++ b/config/config.py
@@ -2,7 +2,7 @@ from ceph_installer import hooks
 
 # Server Specific Configurations
 server = {
-    'port': '8080',
+    'port': '8181',
     'host': '0.0.0.0'
 }
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'pecan-notario',
         'notario>=0.0.11',
         'tambo',
+        'requests',
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
This command would allow to query tasks by their identifier, including a `--poll` flag that will keep polling until the task completes.

This PR also adds `requests` as a dependency.