### PR TITLE
do not quote extra vars when calling ansible

### DIFF
--- a/ceph_installer/cli/dev.py
+++ b/ceph_installer/cli/dev.py
@@ -53,7 +53,7 @@ class Dev(object):
             "-i", "%s," % parser.unknown_commands[-1],
             high_verbosity,
             "-u", user,
-            "--extra-vars", '"branch=%s"' % branch,
+            "--extra-vars", 'branch=%s' % branch,
             "deploy.yml",
         ]
         log.debug("Running command: %s" % ' '.join(command))


### PR DESCRIPTION
Otherwise it just doesn't work and defaults to "master" which we don't want when we are explicitly asking for something else.