### PR TITLE
ceph-installer.spec: require python-tambo

### DIFF
--- a/ceph-installer.spec
+++ b/ceph-installer.spec
@@ -24,6 +24,7 @@ Requires: python-gunicorn
 Requires: python-requests
 Requires: python-pecan-notario
 Requires: rabbitmq-server
+Requires: python-tambo
 Requires(pre):    shadow-utils
 Requires(preun):  systemd
 Requires(postun): systemd


### PR DESCRIPTION
This dependency was added in 664cdbf586b4e2ba5f6821a4998492319160bbdd.  Add it to the RPM packaging as well.