### PR TITLE
util: set fetch_directory to $HOME

### DIFF
--- a/ceph_installer/tests/conftest.py
+++ b/ceph_installer/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from pecan.testing import load_test_app
 
 from copy import deepcopy
@@ -9,6 +10,8 @@ from sqlalchemy.pool import NullPool
 
 from ceph_installer import models as _db
 import pytest
+
+os.environ['HOME'] = tempfile.mkdtemp(suffix='.ceph-installer-home')
 
 DBNAME = 'ceph_installertest.db'
 BIND = 'sqlite:////tmp'

--- a/ceph_installer/tests/test_util.py
+++ b/ceph_installer/tests/test_util.py
@@ -81,7 +81,11 @@ class TestGetInstallExtraVars(object):
     def test_no_extra_vars(self):
         data = dict()
         result = util.get_install_extra_vars(data)
-        assert result == {'ceph_stable': True}
+        expected = {
+            'ceph_stable': True,
+            'fetch_directory': os.path.join(os.environ['HOME'], 'fetch'),
+        }
+        assert result == expected
 
     def test_redhat_storage_is_true(self):
         data = dict(redhat_storage=True)
@@ -92,7 +96,11 @@ class TestGetInstallExtraVars(object):
     def test_redhat_storage_is_false(self):
         data = dict(redhat_storage=False)
         result = util.get_install_extra_vars(data)
-        assert result == {'ceph_stable': True}
+        expected = {
+            'ceph_stable': True,
+            'fetch_directory': os.path.join(os.environ['HOME'], 'fetch'),
+        }
+        assert result == expected
 
 
 class TestGetOSDConfigureExtraVars(object):

--- a/ceph_installer/util.py
+++ b/ceph_installer/util.py
@@ -235,6 +235,9 @@ def get_install_extra_vars(json):
     else:
         # use the latest upstream stable version
         extra_vars["ceph_stable"] = True
+    # fetch_directory must be a writable location.
+    fetch = os.path.join(os.environ['HOME'], 'fetch')
+    extra_vars["fetch_directory"] = fetch
 
     return extra_vars
 


### PR DESCRIPTION
ceph-ansible tries to write to `fetch_directory`. It defaults this variable to the current working directory, and when we're running ansible in prodution, we don't want to grant the UID write access to cwd.

Se fetch_directory to $HOME, since we know that will be writable.