### PR TITLE
tests: store DB in safe tmpdir

### DIFF
--- a/ceph_installer/tests/conftest.py
+++ b/ceph_installer/tests/conftest.py
@@ -14,7 +14,7 @@ import pytest
 os.environ['HOME'] = tempfile.mkdtemp(suffix='.ceph-installer-home')
 
 DBNAME = 'ceph_installertest.db'
-BIND = 'sqlite:////tmp'
+BIND = 'sqlite:///' + os.environ['HOME']
 
 
 def config_file():


### PR DESCRIPTION
Don't hardcode the location to `/tmp/ceph_installertest.db` in the test suite. This avoids symlink race attacks.