### PR TITLE
doc: fix rST syntax

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -277,7 +277,7 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
 
 
 ``agent``
-=======
+=========
 
 .. http:post:: /api/agent/
 


### PR DESCRIPTION
Fixes this warning/error in Jenkins:

```
/docs/source/index.rst:280: WARNING: Title underline too short.
```