### PR TITLE
Don't default to using localhost always for the master location

### DIFF
--- a/ceph_installer/controllers/agent.py
+++ b/ceph_installer/controllers/agent.py
@@ -21,10 +21,13 @@ class AgentController(object):
         error(405)
 
     @index.when(method='POST', template='json')
-    @validate(schemas.install_schema, handler="/errors/schema")
+    @validate(schemas.agent_install_schema, handler="/errors/schema")
     def install(self):
+        master = request.json.get('master', 'localhost')
+        logger.info('defining "%s" as the master host for the minion configuration', master)
         hosts = request.json.get('hosts')
         extra_vars = util.get_install_extra_vars(request.json)
+        extra_vars['agent_master_host'] = master
         identifier = str(uuid4())
         task = models.Task(
             identifier=identifier,

--- a/ceph_installer/controllers/agent.py
+++ b/ceph_installer/controllers/agent.py
@@ -23,7 +23,7 @@ class AgentController(object):
     @index.when(method='POST', template='json')
     @validate(schemas.agent_install_schema, handler="/errors/schema")
     def install(self):
-        master = request.json.get('master', 'localhost')
+        master = request.json.get('master', request.server_name)
         logger.info('defining "%s" as the master host for the minion configuration', master)
         hosts = request.json.get('hosts')
         extra_vars = util.get_install_extra_vars(request.json)

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -28,8 +28,6 @@ install_schema = (
 agent_install_schema = (
     ("hosts", list_of_hosts),
     (optional("master"), types.string),
-    (optional("redhat_storage"), types.boolean),
-    (optional("redhat_use_cdn"), types.boolean),
 )
 
 mon_configure_schema = (

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -25,6 +25,13 @@ install_schema = (
     (optional("redhat_use_cdn"), types.boolean),
 )
 
+agent_install_schema = (
+    ("hosts", list_of_hosts),
+    (optional("master"), types.string),
+    (optional("redhat_storage"), types.boolean),
+    (optional("redhat_use_cdn"), types.boolean),
+)
+
 mon_configure_schema = (
     (optional("cluster_network"), types.string),
     ("fsid", types.string),

--- a/ceph_installer/tests/conftest.py
+++ b/ceph_installer/tests/conftest.py
@@ -22,6 +22,19 @@ def config_file():
     return os.path.join(here, 'config.py')
 
 
+@pytest.fixture
+def argtest():
+    """
+    Simple helper to use with monkeypatch so that a callable can be inspected
+    afterwards to see if it was called with certain arguments.
+    """
+    class TestArgs(object):
+        def __call__(self, *args, **kwargs):
+            self.args = list(args)
+            self.kwargs = kwargs
+    return TestArgs()
+
+
 @pytest.fixture(scope='session')
 def app(request):
     config = configuration.conf_from_file(config_file()).to_dict()

--- a/ceph_installer/tests/controllers/test_agent.py
+++ b/ceph_installer/tests/controllers/test_agent.py
@@ -3,15 +3,6 @@ from ceph_installer.controllers import agent
 
 class TestAgentController(object):
 
-    def setup(self):
-        self.configure_data = dict(
-            monitor_secret="secret",
-            public_network="0.0.0.0/24",
-            host="node1",
-            monitor_interface="eth0",
-            fsid="1720107309134",
-        )
-
     def test_index_get_is_not_allowed(self, session):
         result = session.app.get("/api/agent/", expect_errors=True)
         assert result.status_int == 405
@@ -29,3 +20,26 @@ class TestAgentController(object):
         assert result.json['endpoint'] == '/api/agent/'
         assert result.json['identifier'] is not None
 
+    def test_invalid_master_value_is_detected(self, session, monkeypatch):
+        data = dict(hosts=["google.com"], master=1)
+        result = session.app.post_json("/api/agent/", params=data,
+                                       expect_errors=True)
+        assert result.status_int == 400
+        assert result.json['message'].endswith('not of type string')
+
+    def test_master_is_defined_and_used(self, session, monkeypatch, argtest):
+        monkeypatch.setattr(agent.call_ansible, 'apply_async', argtest)
+        data = dict(hosts=["node1"], master='installer.host')
+        session.app.post_json("/api/agent/", params=data)
+        # argtest.kwargs['kwargs'] may look a bit redundant, but celery tasks
+        # require that same signature as the 'recorder' fixture we have to
+        # capture args and kwargs
+        ansible_extra_args = argtest.kwargs['kwargs']['extra_vars']
+        assert ansible_extra_args['agent_master_host'] == 'installer.host'
+
+    def test_master_is_not_defined_and_is_inferred(self, session, monkeypatch, argtest):
+        monkeypatch.setattr(agent.call_ansible, 'apply_async', argtest)
+        data = dict(hosts=["node1"])
+        session.app.post_json("/api/agent/", params=data)
+        ansible_extra_args = argtest.kwargs['kwargs']['extra_vars']
+        assert ansible_extra_args['agent_master_host'] == 'localhost'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -312,13 +312,15 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
 
       {
           "hosts": ["mon1.example.com", "mon2.example.com", "mon3.example.com"],
+          "master": "master.example.com"
       }
 
    :<json array hosts: (required) The hostnames to which to install and
-                                  configure. For simplicity's sake, the agent
-                                  host's salt-minion will point at a salt
-                                  master on the same host where ceph-installer
-                                  is running.
+                       configure. For simplicity's sake, the agent host's
+                       salt-minion will point at a salt master on the same host
+                       where ceph-installer is running.
+   :<json string master: (optional) If not provided, it will look at the
+                         request and use ``SERVER_NAME``.
 
 
 ``mon``


### PR DESCRIPTION
Allow for a request to define it via JSON, falling back to using `SERVER_NAME` otherwise.

Fixes issue in https://bugzilla.redhat.com/show_bug.cgi?id=1316105