### PR TITLE
calamari install/configuration with mon controllers

### DIFF
--- a/ceph_installer/controllers/mon.py
+++ b/ceph_installer/controllers/mon.py
@@ -67,6 +67,10 @@ class MONController(object):
         # even with configuring we need to tell ceph-ansible
         # if we're working with upstream ceph or red hat ceph storage
         extra_vars = util.get_install_extra_vars(request.json)
+        # this update will take everything in the ``request.json`` body and
+        # just pass it in as extra-vars. That is the reason why optional values
+        # like "calamari" are not looked up explicitly. If they are passed in
+        # they will be used.
         extra_vars.update(request.json)
         if monitors:
             hosts.extend(util.parse_monitors(monitors))

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -49,6 +49,13 @@ agent_install_schema = (
     (optional("master"), types.string),
 )
 
+mon_install_schema = (
+    (optional("calamari"), types.boolean),
+    ("hosts", list_of_hosts),
+    (optional("redhat_storage"), types.boolean),
+    (optional("redhat_use_cdn"), types.boolean),
+)
+
 mon_configure_schema = (
     (optional("cluster_network"), types.string),
     ("fsid", types.string),

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -57,6 +57,7 @@ mon_install_schema = (
 )
 
 mon_configure_schema = (
+    (optional("calamari"), types.boolean),
     (optional("cluster_network"), types.string),
     ("fsid", types.string),
     ("host", types.string),

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -328,7 +328,9 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
 
 .. http:post:: /api/mon/install/
 
-   Start the installation process for monitor(s)
+   Start the installation process for monitor(s). It is allowed to flag the
+   need to install the ``calamari-server`` package which provides a restful API
+   for a cluster.
 
    **Response**:
 
@@ -358,11 +360,14 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
 
 
       {
+          "calamari": false,
           "hosts": ["mon1.example.com", "mon2.example.com", "mon3.example.com"],
           "redhat_storage": false,
           "redhat_use_cdn": true,
       }
 
+   :<json boolean calamari: (optional) include installation of the ``calamari-server`` (a.k.a.
+                                   ``calamari-lite``. Defaults to ``false``.
    :<json array hosts: (required) The hostname to configure
    :<json boolean redhat_storage: (optional) Use the downstream version of
                                   Red Hat Ceph Storage.
@@ -385,6 +390,7 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
       Content-Type: application/json
 
       {
+          "calamari": false,
           "host": "mon1.example.com",
           "monitor_interface": "eth0",
           "fsid": "deedcb4c-a67a-4997-93a6-92149ad2622a",
@@ -396,6 +402,8 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
       }
 
 
+   :<json boolean calamari: (optional) include configuration of the ``calamari-server`` (a.k.a.
+                                   ``calamari-lite``. Defaults to ``false``.
    :<json string fsid: (required) The ``fsid`` for the cluster
    :<json string host: (required) The hostname to configure
    :<json string monitor_interface: (required) The interface name (e.g. "eth0")


### PR DESCRIPTION
This PR allows to flag with a boolean the need to install/configure the calamari-server when provisioning monitors