### PR TITLE
(cli) ceph-installer address

### DIFF
--- a/ceph_installer/cli/constants.py
+++ b/ceph_installer/cli/constants.py
@@ -1,2 +1,3 @@
+import os
 
-server_address = 'http://localhost:8181/'
+server_address = os.environ.get('CEPH_INSTALLER_ADDRESS', 'http://localhost:8181/')

--- a/ceph_installer/cli/main.py
+++ b/ceph_installer/cli/main.py
@@ -3,7 +3,7 @@ import sys
 from tambo import Transport
 import ceph_installer
 from ceph_installer.cli import log
-from ceph_installer.cli import dev, task
+from ceph_installer.cli import dev, task, constants
 from ceph_installer.cli.decorators import catches
 
 
@@ -12,6 +12,7 @@ class CephInstaller(object):
 A command line utility to install and configure Ceph using an HTTP API as a REST service
 to call Ansible.
 
+Address: %s
 Version: %s
 
 Global Options:
@@ -19,6 +20,9 @@ Global Options:
 --log, --logging    Set the level of logging. Acceptable values:
                     debug, warning, error, critical
 
+Environment Variables:
+CEPH_INSTALLER_ADDRESS    Define the location of the installer.
+                          Defaults to "http://localhost:8181"
 
 %s
     """
@@ -34,7 +38,10 @@ Global Options:
 
     def help(self, subhelp):
         version = ceph_installer.__version__
-        return self._help % (version, subhelp)
+        return self._help % (
+            constants.server_address, version,
+            subhelp
+        )
 
     @catches(KeyboardInterrupt, handle_all=True, logger=log)
     def main(self, argv):


### PR DESCRIPTION
Allow to define the installer location with an environment variable. Fallback to `http://localhost:8181` and show the current value in the help menu