### PR TITLE
allow ceph.conf to be modified/configured

### DIFF
--- a/ceph_installer/controllers/mon.py
+++ b/ceph_installer/controllers/mon.py
@@ -78,6 +78,9 @@ class MONController(object):
         extra_vars.update(request.json)
         if 'verbose' in extra_vars:
             del extra_vars['verbose']
+        if 'conf' in extra_vars:
+            extra_vars['ceph_conf_overrides'] = request.json['conf']
+            del extra_vars['conf']
         if monitors:
             hosts.extend(util.parse_monitors(monitors))
             del extra_vars['monitors']
@@ -95,7 +98,7 @@ class MONController(object):
             extra_vars=extra_vars,
             skip_tags="package-install",
             verbose=verbose_ansible,
-            )
+        )
         call_ansible.apply_async(
             args=([('mons', hosts)], identifier),
             kwargs=kwargs,

--- a/ceph_installer/controllers/osd.py
+++ b/ceph_installer/controllers/osd.py
@@ -66,6 +66,9 @@ class OSDController(object):
         extra_vars = util.get_osd_configure_extra_vars(request.json)
         if 'verbose' in extra_vars:
             del extra_vars['verbose']
+        if 'conf' in extra_vars:
+            extra_vars['ceph_conf_overrides'] = request.json['conf']
+            del extra_vars['conf']
         identifier = str(uuid4())
         task = models.Task(
             identifier=identifier,

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -38,6 +38,14 @@ def list_of_monitors(value):
         assert "interface" in monitor, msg
 
 
+conf = (
+    (optional("global"), types.dictionary),
+    (optional("mds"), types.dictionary),
+    (optional("mon"), types.dictionary),
+    (optional("osd"), types.dictionary),
+    (optional("rgw"), types.dictionary),
+)
+
 install_schema = (
     ("hosts", list_of_hosts),
     (optional("redhat_storage"), types.boolean),

--- a/ceph_installer/schemas.py
+++ b/ceph_installer/schemas.py
@@ -70,6 +70,7 @@ mon_install_schema = (
 mon_configure_schema = (
     (optional("calamari"), types.boolean),
     (optional("cluster_network"), types.string),
+    (optional("conf"), conf),
     ("fsid", types.string),
     ("host", types.string),
     ("monitor_interface", types.string),
@@ -82,6 +83,7 @@ mon_configure_schema = (
 
 osd_configure_schema = (
     (optional("cluster_network"), types.string),
+    (optional("conf"), conf),
     ("devices", devices_object),
     ("fsid", types.string),
     ("host", types.string),

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -395,6 +395,7 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
 
       {
           "calamari": false,
+          "conf": {"global": {"auth supported": "cephx"}},
           "host": "mon1.example.com",
           "monitor_interface": "eth0",
           "fsid": "deedcb4c-a67a-4997-93a6-92149ad2622a",
@@ -409,6 +410,9 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
 
    :<json boolean calamari: (optional) include configuration of the ``calamari-server`` (a.k.a.
                                    ``calamari-lite``. Defaults to ``false``.
+   :<json object conf: (optional) An object that maps ceph.conf sections (only
+                       global, mon, osd, rgw, mds allowed) to keys and values. Anything defined in
+                       this mapping will override existing settings.
    :<json string fsid: (required) The ``fsid`` for the cluster
    :<json string host: (required) The hostname to configure
    :<json string monitor_interface: (required) The interface name (e.g. "eth0")
@@ -487,6 +491,7 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
       Content-Type: application/json
 
       {
+          "conf": {"global": {"auth supported": "cephx"}},
           "devices": {"/dev/sdb":"/dev/sdc"},
           "fsid": "deedcb4c-a67a-4997-93a6-92149ad2622a",
           "host": "osd1.example.com",
@@ -498,6 +503,9 @@ Polling is not subject to handle state with HTTP status codes (e.g. 304)
           "verbose": false,
       }
 
+   :<json object conf: (optional) An object that maps ceph.conf sections (only
+                       global, mon, osd, rgw, mds allowed) to keys and values. Anything defined in
+                       this mapping will override existing settings.
    :<json object devices: (required) A mapping of OSD device to Journal
                           like device: {"device": "journal"}.
    :<json string fsid: (required) The ``fsid`` for the cluster


### PR DESCRIPTION
For mon and osd configure operations only.

Related to BZ https://bugzilla.redhat.com/show_bug.cgi?id=1314855