### PR TITLE
set monitor_name when host is a mon and osd in osd/configure/

### DIFF
--- a/ceph_installer/tests/controllers/test_osd.py
+++ b/ceph_installer/tests/controllers/test_osd.py
@@ -110,6 +110,20 @@ class TestOSDController(object):
         assert result.status_int == 400
         assert "unexpected item in data" in result.json["message"]
 
+    def test_configure_monitor_name_is_set(self, session, monkeypatch, argtest):
+        monkeypatch.setattr(
+            osd.call_ansible, 'apply_async', argtest)
+        self.configure_data['host'] = "mon1.host"
+        session.app.post_json("/api/osd/configure/", params=self.configure_data)
+        kwargs = argtest.kwargs['kwargs']
+        assert kwargs['extra_vars']['monitor_name'] == "mon1.host"
+
+    def test_configure_monitor_name_is_not_set(self, session, monkeypatch, argtest):
+        monkeypatch.setattr(
+            osd.call_ansible, 'apply_async', argtest)
+        session.app.post_json("/api/osd/configure/", params=self.configure_data)
+        kwargs = argtest.kwargs['kwargs']
+        assert "monitor_name" not in kwargs['extra_vars']
 
 
 class TestOsdVerbose(object):

--- a/ceph_installer/tests/test_util.py
+++ b/ceph_installer/tests/test_util.py
@@ -157,6 +157,14 @@ class TestGetOSDConfigureExtraVars(object):
         result = util.get_osd_configure_extra_vars(self.data)
         assert result["devices"] == ["/dev/sdb"]
 
+    def test_monitor_name_is_set(self):
+        # simulates the scenario where this host is a mon and an osd
+        data = self.data.copy()
+        data['host'] = "mon1.host"
+        result = util.get_osd_configure_extra_vars(data)
+        assert "monitor_name" in result
+        assert result['monitor_name'] == "mon1.host"
+
 
 class TestParseMonitors(object):
 

--- a/ceph_installer/util.py
+++ b/ceph_installer/util.py
@@ -282,6 +282,16 @@ def get_osd_configure_extra_vars(json):
     extra_vars['devices'] = devices
     extra_vars['raw_journal_devices'] = journal_devices
 
+    monitor_hosts = [mon['host'] for mon in json["monitors"]]
+    host = json['host']
+    if host in monitor_hosts:
+        logger.info("The host %s is in both the OSD and MON groups.", host)
+        # The role ceph-mon isn't used during on OSD configure so the
+        # monitor_name variable is never set, but it needs to exist because
+        # the ceph-common role will attempt to restart mons because this host
+        # is both a mon and an osd.
+        extra_vars['monitor_name'] = host
+
     # These are items that came via the JSON that should never be passed into
     # ceph-ansible because they are no longer needed
     del extra_vars['host']


### PR DESCRIPTION
The var monitor_name is set in the ceph-mon role and is needed to
restart the monitors. Because we're configuring an osd that is also a
mon, we need to restart the monitor process as well. Without using the
ceph-mon role we manually set monitor_name so that the process
will restart correctly.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>