### PR TITLE
import gitchangelog config file

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -1,0 +1,3 @@
+tag_filter_regexp = r'^v[0-9]+\.[0-9]+(\.[0-9]+)?$'
+ignore_regexps = [ r'^version [0-9]+\.[0-9]+(\.[0-9]+)?.' ]
+include_merge = False


### PR DESCRIPTION
gitchangelog is useful for quickly and accurately writing entries for `changelog.rst`.