### PR TITLE
support in-n-out unicode because sqlite

### DIFF
--- a/ceph_installer/models/tasks.py
+++ b/ceph_installer/models/tasks.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String,  Boolean, DateTime, Text
+from sqlalchemy import Column, Integer, String,  Boolean, DateTime, UnicodeText
 from sqlalchemy.orm.exc import DetachedInstanceError
 from ceph_installer.models import Base
 
@@ -10,8 +10,8 @@ class Task(Base):
     identifier = Column(String(256), unique=True, nullable=False, index=True)
     endpoint = Column(String(256), index=True)
     command = Column(String(256))
-    stderr = Column(Text)
-    stdout = Column(Text)
+    stderr = Column(UnicodeText)
+    stdout = Column(UnicodeText)
     started = Column(DateTime)
     ended = Column(DateTime)
     succeeded = Column(Boolean(), default=False)

--- a/ceph_installer/process.py
+++ b/ceph_installer/process.py
@@ -71,4 +71,8 @@ def run(arguments, send_input=None, **kwargs):
         out, err = process.communicate(send_input)
     else:
         out, err = process.communicate()
+
+    # Ensure we are dealing with strings (might get a None) and decode them
+    out = str(out).decode('utf-8', 'replace')
+    err = str(err).decode('utf-8', 'replace')
     return out, err, process.returncode


### PR DESCRIPTION
To prevent:

    (ProgrammingError) You must not use 8-bit bytestrings unless you use a text_factory that can interpret 8-bit bytestrings (like text_factory = str). It is highly recommended that you instead just switch your application to Unicode strings. u\'UPDATE tasks SET stderr=?, stdout=?, ended=?, succeeded=?, exit_code=? WHERE tasks.id = ?\' (\'\', \'\\nPLAY [mons] ....
