### PR TITLE
systemd: log STDOUT and STDERR to the journal

### DIFF
--- a/systemd/ceph-installer-celery.service
+++ b/systemd/ceph-installer-celery.service
@@ -9,6 +9,8 @@ ExecStart=/usr/bin/celery -A async worker --loglevel=info
 EnvironmentFile=-/etc/sysconfig/ceph-installer
 User=ceph-installer
 WorkingDirectory=/usr/lib/python2.7/site-packages/ceph_installer
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/ceph-installer.service
+++ b/systemd/ceph-installer.service
@@ -9,6 +9,8 @@ ExecStart=/usr/bin/gunicorn_pecan -w 10 -t 300 /etc/ceph-installer/config.py
 EnvironmentFile=-/etc/sysconfig/ceph-installer
 User=ceph-installer
 WorkingDirectory=/usr/lib/python2.7/site-packages/ceph_installer/
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I *think* "StandardOutput=journal" is already the default, but "StandardError=journal" is not.

At any rate, send them both to the same place.