### PR TITLE
/setup/key: log stdout and stderr

### DIFF
--- a/ceph_installer/controllers/setup.py
+++ b/ceph_installer/controllers/setup.py
@@ -50,7 +50,7 @@ class SetupController(object):
             ]
             out, err, code = process.run(command, send_input='y\n')
             if code != 0:
-                error(500, err)
+                error(500, 'stdout: "%s" stderr: "%s"' % (out, err))
 
         # define the file to download
         response.headers['Content-Disposition'] = 'attachment; filename=id_rsa.pub'

--- a/ceph_installer/tests/controllers/test_setup.py
+++ b/ceph_installer/tests/controllers/test_setup.py
@@ -42,4 +42,4 @@ class TestSetupController(object):
             'run',
             lambda x, send_input: ('', 'no can ssh', 123))
         result = session.app.get('/setup/key/', expect_errors=True)
-        assert result.json['message'] == 'no can ssh'
+        assert result.json['message'] == 'stdout: "" stderr: "no can ssh"'


### PR DESCRIPTION
The /setup/key/ controller  can sometimes fail, and the JSON response is
less than helpful:

      {"message": ""}

I assume this means that the ssh-keygen error was written to stdout
rather than stderr. Pass both stdout and stderr to the error controller.