### PR TITLE
doc: the changelog must be updated during a release

### DIFF
--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -5,6 +5,9 @@ ceph-installer release process
 
 When you are ready to cut a new version:
 
+#. Modify ``docs/source/changelog.rst`` with the changes since the latest
+   release. Optionally, the ``gitchangelog`` program can help you write this.
+
 #. Bump the version number in ceph_installer/__init__.py.
    ::
 


### PR DESCRIPTION
Add a note to `releasing.rst` indicating that the maintainer must edit the `changelog.rst` file during each release.