### PR TITLE
doc: add changelog for v1.0.6

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,19 @@
 changelog
 =========
 
+v1.0.6 (2016-04-29)
+-------------------
+
+- When the ``/setup/key/`` controller experiences a failure during the
+  ``ssh-keygen`` operation, it will now return both the STDOUT and STDERR
+  output from the failed key generation operation. Prior to this change, the
+  controller would only return STDERR, and STDOUT was lost. The purpose of
+  this change is to make it easier to debug when ``ssh-keygen`` fails.
+
+- The systemd units now cause the ``ceph-installer`` and
+  ``ceph-installer-celery`` services to log both STDOUT and STDERR to the
+  systemd journal.
+
 1.0.5 (2016-04-19)
 ------------------
 


### PR DESCRIPTION
I mistakenly ommitted this in the prior "version 1.0.6" commit
(3de0c1cfa480d26c34d22a085d2dedbd2d4d7d34).