### PR TITLE
util: add trailing newline to inventory files

### DIFF
--- a/ceph_installer/util.py
+++ b/ceph_installer/util.py
@@ -29,7 +29,7 @@ def generate_inventory_file(inventory, task_uuid, tmp_dir=None):
         if not isinstance(hosts, list):
             hosts = [hosts]
         result.extend(hosts)
-    result_str = "\n".join(result)
+    result_str = "\n".join(result) + "\n"
     # if not None the NamedTemporaryFile will be created in the given directory
     tempfile.tempdir = tmp_dir
     inventory_file = tempfile.NamedTemporaryFile(prefix="{0}_".format(task_uuid), delete=False)


### PR DESCRIPTION
In simple cluster cases (like a single monitor), this inventory file may only have one host. If it's the last line in the file, `cat` puts it on the same line as the prompt... which makes my eyes skip over it, thinking it's empty.

Add a trailing newline so it's easier to quickly read the file with `cat`.