### PR TITLE
setup: log ssh-keygen failures on the server

### DIFF
--- a/ceph_installer/controllers/setup.py
+++ b/ceph_installer/controllers/setup.py
@@ -50,6 +50,7 @@ class SetupController(object):
             ]
             out, err, code = process.run(command, send_input='y\n')
             if code != 0:
+                logger.error('ssh-keygen failed: %s %s' % (out, err))
                 error(500, 'stdout: "%s" stderr: "%s"' % (out, err))
 
         # define the file to download


### PR DESCRIPTION
Prior to this change, if ssh-keygen failed, we would return the error message to the client via JSON, but we would not log anything on the server-side.

This is a serious-enough condition that we should log to the server as well.