### PR TITLE
templates: install python during bootstrap

### DIFF
--- a/ceph_installer/templates.py
+++ b/ceph_installer/templates.py
@@ -19,6 +19,12 @@ if [ "$ID" != "ubuntu" ] && [ "$ID" != "rhel" ]; then
 fi
 
 
+if [ "$ID" == "ubuntu" ]; then
+    echo "--> Installing Python 2.7 for Ansible"
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get -y install python
+fi
+
 echo "--> creating new user with disabled password: ceph-installer"
 useradd -m ceph-installer
 passwd -d ceph-installer

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ The top level endpoints are:
   script should be executed with super user privileges on the remote node as it
   will perform the following actions:
 
+  * Ensure that Python 2 is present on the system
   * create an ``ceph-installer`` user
   * ensure that the ``ceph-installer`` user can use sudo without a password
     prompt


### PR DESCRIPTION
Xenial does not have "python" (py27) installed by default, which will cause Ansible failures.

Ensure that it's present as part of the bootstrap step.