### PR TITLE
add request metadata as part of a task

### DIFF
--- a/ceph_installer/controllers/mon.py
+++ b/ceph_installer/controllers/mon.py
@@ -36,6 +36,7 @@ class MONController(object):
         extra_vars['calamari'] = install_calamari
         identifier = str(uuid4())
         task = models.Task(
+            request=request,
             identifier=identifier,
             endpoint=request.path,
         )
@@ -98,6 +99,7 @@ class MONController(object):
         extra_vars.pop('address', None)
         identifier = str(uuid4())
         task = models.Task(
+            request=request,
             identifier=identifier,
             endpoint=request.path,
         )

--- a/ceph_installer/controllers/osd.py
+++ b/ceph_installer/controllers/osd.py
@@ -33,6 +33,7 @@ class OSDController(object):
         extra_vars = util.get_install_extra_vars(request.json)
         identifier = str(uuid4())
         task = models.Task(
+            request=request,
             identifier=identifier,
             endpoint=request.path,
         )
@@ -71,6 +72,7 @@ class OSDController(object):
             del extra_vars['conf']
         identifier = str(uuid4())
         task = models.Task(
+            request=request,
             identifier=identifier,
             endpoint=request.path,
         )

--- a/ceph_installer/controllers/rgw.py
+++ b/ceph_installer/controllers/rgw.py
@@ -30,6 +30,7 @@ class RGWController(object):
         hosts = request.json.get('hosts')
         identifier = str(uuid4())
         task = models.Task(
+            request=request,
             identifier=identifier,
             endpoint=request.path,
         )

--- a/ceph_installer/models/tasks.py
+++ b/ceph_installer/models/tasks.py
@@ -20,6 +20,16 @@ class Task(Base):
     succeeded = Column(Boolean(), default=False)
     exit_code = Column(Integer)
 
+    def __init__(self, request=None, **kw):
+        self._extract_request_metadata(request)
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+    def _extract_request_metadata(self, request):
+        self.http_method = getattr(request, 'method', '')
+        self.request = str(getattr(request, 'body', ''))
+        self.user_agent = getattr(request, 'user_agent', '')
+
     def __repr__(self):
         try:
             return '<Task %r>' % self.identifier

--- a/ceph_installer/models/tasks.py
+++ b/ceph_installer/models/tasks.py
@@ -9,6 +9,9 @@ class Task(Base):
     id = Column(Integer, primary_key=True)
     identifier = Column(String(256), unique=True, nullable=False, index=True)
     endpoint = Column(String(256), index=True)
+    user_agent = Column(String(512))
+    request = Column(UnicodeText)
+    http_method = Column(String(64))
     command = Column(String(256))
     stderr = Column(UnicodeText)
     stdout = Column(UnicodeText)
@@ -34,4 +37,7 @@ class Task(Base):
             ended = self.ended,
             succeeded = self.succeeded,
             exit_code = self.exit_code,
+            user_agent = self.user_agent,
+            request = self.request,
+            http_method = self.http_method,
         )

--- a/ceph_installer/tests/conftest.py
+++ b/ceph_installer/tests/conftest.py
@@ -23,6 +23,15 @@ def config_file():
 
 
 @pytest.fixture
+def fake():
+    class Fake(object):
+        def __init__(self, *a, **kw):
+            for k, v, in kw.items():
+                setattr(self, k, v)
+    return Fake
+
+
+@pytest.fixture
 def argtest():
     """
     Simple helper to use with monkeypatch so that a callable can be inspected

--- a/ceph_installer/tests/test_tasks.py
+++ b/ceph_installer/tests/test_tasks.py
@@ -58,3 +58,15 @@ class TestCallAnsible(object):
         tasks.call_ansible.apply(args=([], 'aaaa')).get()
         task = models.Task.get(1)
         assert task.stdout == u'\xa3'
+
+    def test_process_a_request_that_is_none(self, session, monkeypatch):
+        monkeypatch.setattr(
+            tasks.process,
+            'make_ansible_command',
+            lambda *a, **kw: ['echo']
+        )
+        tasks.call_ansible.apply(args=([], 'aaaa')).get()
+        task = models.Task.get(1)
+        assert task.http_method == ''
+        assert task.user_agent == ''
+        assert task.request == ''


### PR DESCRIPTION
Fixes issue #141 

    {
    
        "endpoint": "/api/mon/install/",
        "succeeded": false,
        "stdout": "",
        "started": "2016-05-06 14:43:37.023990",
        "request": "{\"calamari\": true, \"hosts\": [\"node6\"],\"redhat_storage\":false,\"redhat_use_cdn\":true}",
        "exit_code": ​1,
        "ended": "2016-05-06 14:43:37.206097",
        "http_method": "POST",
        "command": "/usr/local/bin/ansible-playbook -v -u ceph-installer /opt/ceph-installer/ceph-ansible/site.yml.sample -i /tmp/9764f967-53d9-484c-95eb-607d0a63110c_zwwA5H --extra-vars {\"calamari\": true, \"ceph_stable\": true, \"fetch_directory\": \"/home/vagrant/fetch\"} --tags package-install",
        "user_agent": "curl/7.43.0",
        "stderr": "Traceback (most recent call last):\n  File \"/usr/local/bin/ansible-playbook\", line 44, in <module>\n    import ansible.playbook\n  File \"/usr/local/lib/python2.7/dist-packages/ansible/playbook/__init__.py\", line 20, in <module>\n    import ansible.runner\n  File \"/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py\", line 32, in <module>\n    import jinja2\n  File \"/usr/local/lib/python2.7/dist-packages/jinja2/__init__.py\", line 33, in <module>\n    from jinja2.environment import Environment, Template\n  File \"/usr/local/lib/python2.7/dist-packages/jinja2/environment.py\", line 13, in <module>\n    from jinja2 import nodes\n  File \"/usr/local/lib/python2.7/dist-packages/jinja2/nodes.py\", line 19, in <module>\n    from jinja2.utils import Markup\n  File \"/usr/local/lib/python2.7/dist-packages/jinja2/utils.py\", line 531, in <module>\n    from markupsafe import Markup, escape, soft_unicode\nImportError: No module named markupsafe\n",
        "identifier": "9764f967-53d9-484c-95eb-607d0a63110c"
    
    }
