### PR TITLE
/setup/key/: don't run ssh-keygen during HTTP request

### DIFF
--- a/ceph_installer/app.py
+++ b/ceph_installer/app.py
@@ -6,13 +6,10 @@ from ceph_installer.util import mkdir
 
 def ensure_ssh_keys():
     """
-    This helper is mostly duplicated from the ``/setup/key`` controller, it
-    exists here so that ssh keys can be ensure as early as possible to avoid
-    race conditions because ssh-keygen might take a bit too long to complete.
-    It is safe to keep the duplication on ``/setup/key`` so that it can still
-    ensure keys if that ever happens. This version of the helper does not use
-    logging because it is too early in running the application and no logging
-    has been configured yet.
+    Generate ssh keys as early as possible so that they are available to all
+    web server workers immediately when serving ``/setup/key/``. This helper
+    does not use logging because it is too early in running the application
+    and no logging has been configured yet.
     """
     # look for the ssh key of the current user
     private_key_path = os.path.expanduser('~/.ssh/id_rsa')

--- a/ceph_installer/controllers/setup.py
+++ b/ceph_installer/controllers/setup.py
@@ -35,23 +35,14 @@ class SetupController(object):
         ssh_dir = os.path.dirname(public_key_path)
 
         if not os.path.isdir(ssh_dir):
-            logger.warning('.ssh directory not found, creating one at: %s', ssh_dir)
-            mkdir(ssh_dir)
+            msg = '.ssh directory not found: %s' % ssh_dir
+            logger.error(msg)
+            error(500, msg)
 
-        # if there isn't one create it
         if not os.path.exists(public_key_path):
-            logger.warning('expected public key not found: %s', public_key_path)
-            logger.warning('will create new ssh key pair')
-            # create one
-            command = [
-                    'ssh-keygen', '-q', '-t', 'rsa',
-                    '-N', '',
-                    '-f', private_key_path,
-            ]
-            out, err, code = process.run(command, send_input='y\n')
-            if code != 0:
-                logger.error('ssh-keygen failed: %s %s' % (out, err))
-                error(500, 'stdout: "%s" stderr: "%s"' % (out, err))
+            msg = 'expected public key not found: %s' % public_key_path
+            logger.error(msg)
+            error(500, msg)
 
         # define the file to download
         response.headers['Content-Disposition'] = 'attachment; filename=id_rsa.pub'


### PR DESCRIPTION
Commit f8deeae628748be69e47cc23ace4f951a960fc9e changed the ceph-installer application to run `ssh-keygen` as part of the start up process. If `ssh-keygen` fails, then the app will fail to start (raising a RuntimeError).

In other words, we can trust that the SSH public key file will always be available when a client hits the /setup/key/ endpoint. If the file is missing at this point, we should treat that as a hard error condition (logging on the server, returning an HTTP error to the client), and never try to generate an SSH key within the gunicorn child worker process.

The purpose of this change is to further harden the code against races during /setup/key/, where more than one worker could possibly run `ssh-keygen` at the same time.