### PR TITLE
adds a man page for the ceph-installer cli tool

### DIFF
--- a/ceph_installer/controllers/setup.py
+++ b/ceph_installer/controllers/setup.py
@@ -1,7 +1,6 @@
 from pecan import expose, request, response
 from webob.static import FileIter
-from ceph_installer.util import make_setup_script, make_agent_script, mkdir
-from ceph_installer import process
+from ceph_installer.util import make_setup_script, make_agent_script
 from ceph_installer.controllers import error
 import os
 from StringIO import StringIO
@@ -30,7 +29,6 @@ class SetupController(object):
         Serves the public SSH key for the user that own the current service
         """
         # look for the ssh key of the current user
-        private_key_path = os.path.expanduser('~/.ssh/id_rsa')
         public_key_path = os.path.expanduser('~/.ssh/id_rsa.pub')
         ssh_dir = os.path.dirname(public_key_path)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -216,7 +216,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'ceph_installer', u'Ceph-Installer Documentation',
+    ('man/index', 'ceph-installer', u'Ceph-Installer CLI Documentation',
      [u'Authors'], 1)
 ]
 

--- a/docs/source/man/index.rst
+++ b/docs/source/man/index.rst
@@ -1,0 +1,68 @@
+ceph-installer
+==============
+
+A command line utility to install and configure Ceph using an HTTP API as a REST service
+to call Ansible.
+
+Global Options
+--------------
+
+-h, --help, help    Show this program's help menu
+
+--log, --logging    Set the level of logging. Acceptable values: debug, warning, error, critical
+
+Environment Variables
+---------------------
+
+CEPH_INSTALLER_ADDRESS
+    Define the location of the installer.
+
+    Defaults to "http://localhost:8181"
+
+Commands
+--------
+
+task
+++++
+
+
+Human-readable task information: stdout, stderr, and the ability to "poll"
+a task that waits until the command completes to be able to show the output
+in a readable way.
+
+Usage::
+
+    ceph-installer task $IDENTIFIER
+
+Options::
+
+    --poll        Poll until the task has completed (either on failure or success)
+     stdout        Retrieve the stdout output from the task
+     stderr        Retrieve the stderr output from the task
+     command       The actual command used to call ansible
+     ended         The timestamp (in UTC) when the command completed
+     started       The timestamp (in UTC) when the command started
+     exit_code     The shell exit status for the process
+     succeeded     Boolean value to indicate if process completed correctly
+
+dev
++++
+
+
+Deploying the ceph-installer HTTP service to a remote server with ansible.
+This command wraps ansible and certain flags to make it easier to deploy
+a development version.
+
+Usage::
+
+    ceph-installer dev $HOST
+
+Note: Requires a remote user with passwordless sudo. User defaults to
+"vagrant".
+
+Options:
+
+--user        Define a user to connect to the remote server. Defaults  to 'vagrant'
+--branch      What branch to use for the deployment. Defaults to 'master'
+-vvvv         Enable high verbosity when running ansible
+


### PR DESCRIPTION
The man page can be built by by the command 'make clean man'
while in the ceph-installer/docs directory.