### PR TITLE
ceph-installer.spec: require latest ceph-ansible

### DIFF
--- a/ceph-installer.spec
+++ b/ceph-installer.spec
@@ -15,7 +15,7 @@ Source0:        https://github.com/ceph/%{srcname}/archive/%{commit}/%{srcname}-
 BuildArch:      noarch
 
 Requires: ansible
-Requires: ceph-ansible >= 1.0.2
+Requires: ceph-ansible >= 1.0.5
 Requires: openssh
 Requires: python-celery
 Requires: python-gunicorn


### PR DESCRIPTION
We test with v1.0.5; anything else is not supported.