### PR TITLE
link the cli man page docs from contents.rst

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -24,3 +24,11 @@ Changelog
    :maxdepth: 2
 
    changelog.rst
+
+ceph-installer CLI
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   man/index.rst


### PR DESCRIPTION
This should remove the warning that's causing the docs builds to fail.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>