### PR TITLE
setup.py: make "release" push to master

### DIFF
--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -22,9 +22,3 @@ When you are ready to cut a new version:
    ::
 
       python setup.py release
-
-#. Push your setup.py change directly to master on GitHub.
-   ::
-
-      git push origin master
-

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,11 @@ class ReleaseCommand(Command):
         print ' '.join(cmd)
         subprocess.check_call(cmd)
 
+        # Push master to the remote
+        cmd = ['git', 'push', 'origin', 'master']
+        print ' '.join(cmd)
+        subprocess.check_call(cmd)
+
 
 setup(
     name='ceph-installer',


### PR DESCRIPTION
Remove a manual step from the release process, and have `setup.py release` do it instead.