### PR TITLE
setup.py: add "bump" command

### DIFF
--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -8,15 +8,11 @@ When you are ready to cut a new version:
 #. Modify ``docs/source/changelog.rst`` with the changes since the latest
    release. Optionally, the ``gitchangelog`` program can help you write this.
 
-#. Bump the version number in ceph_installer/__init__.py.
+#. Bump the version number in ``ceph_installer/__init__.py`` and commit your
+   changes.
    ::
 
-      vim ceph_installer/__init__.py
-
-#. Commit your setup.py change as "version 1.2.3".
-   ::
-
-      git commit ceph_installer/__init__.py -m 'version 1.2.3'
+      python setup.py bump
 
 #. Tag and release to PyPI.
    ::

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ except ImportError:
 import re
 
 
-module_file = open("ceph_installer/__init__.py").read()
+def read_module_contents():
+    with open('ceph_installer/__init__.py') as installer_init:
+        return installer_init.read()
+
+module_file = read_module_contents()
 metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
 long_description = open('README.rst').read()
 version = metadata['version']


### PR DESCRIPTION
This command will increment the last number in ``__version__`` automatically and commit all changes to Git with a standard commit message.

(In the vast majority of cases, we simply want to bump the final version number part, so this optimizes for that scenario to make that easier. If we want to go to "2.0.0" or "3.0.0", that will have to be done by hand, or else add more ``user_options`` to this command to make it more flexible.)