### PR TITLE
set CELERYD_CONCURRENCY=1 to ensure there is only one celery worker

### DIFF
--- a/ceph_installer/async.py
+++ b/ceph_installer/async.py
@@ -22,3 +22,7 @@ def bootstrap_pecan(signal, sender):
 
 
 app = Celery('ceph_installer.async', broker='amqp://guest@localhost//', include=['ceph_installer.tasks'])
+# the default value of CELERYD_CONCURRENCY will be set to the number
+# of CPU/cores on the host. This is a problem because we need to ensure
+# that there is only one celery worker running.
+app.conf.update(CELERYD_CONCURRENCY=1)


### PR DESCRIPTION
The default value will create a worker for each CPU/core on the host.
This is a problem because we depend on the tasks to run sequentially and
with multiple workers that won't always be the case.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>