### PR TITLE
ceph-installer.spec: silence install

### DIFF
--- a/ceph-installer.spec
+++ b/ceph-installer.spec
@@ -91,7 +91,7 @@ exit 0
 
 %post
 if [ $1 -eq 1 ] ; then
-   su - ceph-installer -c "/bin/pecan populate /etc/ceph-installer/config.py"
+   su - ceph-installer -c "/bin/pecan populate /etc/ceph-installer/config.py" &> /dev/null
 fi
 %systemd_post ceph-installer.service
 %systemd_post ceph-installer-celery.service


### PR DESCRIPTION
Prior to this change, the "yum install ceph-installer" would print
messages to the console:

  ==> LOADING ENVIRONMENT
  ==> BUILDING SCHEMA
  ==> STARTING A TRANSACTION...
  ==> COMMITING...

Silence these messages by piping them to /dev/null.

Resolves: rhbz#1341686