### PR TITLE
ceph-installer.spec: require Ansible 1.9

### DIFF
--- a/ceph-installer.spec
+++ b/ceph-installer.spec
@@ -14,7 +14,7 @@ Source0:        https://github.com/ceph/%{srcname}/archive/%{commit}/%{srcname}-
 
 BuildArch:      noarch
 
-Requires: ansible
+Requires: ansible < 2
 Requires: ceph-ansible >= 1.0.5
 Requires: openssh
 Requires: python-celery


### PR DESCRIPTION
Don't allow Ansible 2 or above, since we've only tested with Ansible 1.9.

Resolves: rhbz#1349036