### PR TITLE
templates: fix bash shebang

### DIFF
--- a/ceph_installer/templates.py
+++ b/ceph_installer/templates.py
@@ -1,5 +1,5 @@
 
-setup_script = """#!/bin/bash -x -e
+setup_script = """#!/bin/bash
 if [[ $EUID -ne 0 ]]; then
   echo "You must be a root user or execute this script with sudo" 2>&1
   exit 1


### PR DESCRIPTION
Consumers will run something like the following:

    curl http://installer.example.com:8181/setup | sudo bash

Which causes bash to ignore the shebang line entirely (treating it as a simple comment).

However, if a user attempts to download the script and then execute it (using the shebang:)

    curl http://installer.example.com:8181/setup > setup.sh
    chmod +x setup.sh
    ./setup.sh

... then the user will receive an error:

    /bin/bash: - : invalid option
    Usage: /bin/bash [GNU long option] [option] ...
           /bin/bash [GNU long option] [option] script-file ...

If we really want the `-x -e` behavior, it would be better to add `set -ex` as an explicit command in this script, so that it covers both usage scenarios.  However, adding `set -e` now would introduce a behavior change and requires a lot more testing.

This commit simply fixes the shebang so that executing the script directly no longer fails. We could add `set -e` at a later date if we decide it makes sense.