### PR TITLE
selinux: allow cert_t:dir search

### DIFF
--- a/selinux/ceph-installer.te
+++ b/selinux/ceph-installer.te
@@ -79,6 +79,7 @@ optional_policy(`
 ')
 
 allow ceph_installer_t ceph_installer_var_lib_t:sock_file { write create unlink link };
+allow ceph_installer_t cert_t:dir search;
 allow ceph_installer_t cert_t:file { read getattr open };
 allow ceph_installer_t devlog_t:sock_file write;
 allow ceph_installer_t devpts_t:filesystem getattr;


### PR DESCRIPTION
I saw this AVC denial when I tried setting up a cluster in enforcing
mode. It caused Ansible to fail to authenticate to the cluster nodes.