### PR TITLE
selinux: set ceph_installer_t to permissive

### DIFF
--- a/selinux/ceph-installer.te
+++ b/selinux/ceph-installer.te
@@ -80,6 +80,8 @@ optional_policy(`
     apache_search_config(ceph_installer_t)
 ')
 
+permissive ceph_installer_t;
+
 allow ceph_installer_t ceph_installer_var_lib_t:sock_file { write create unlink link };
 allow ceph_installer_t cert_t:dir search;
 allow ceph_installer_t cert_t:file { read getattr open };


### PR DESCRIPTION
We have still found various AVC denials when running Skyring (Tendrl) with SELinux in enforcing mode. To make sure ceph-installer works while we fix the remaining issues with the policies, we are going to set the entire `ceph_installer_t` domain to permissive.

With this change, the ceph-installer service still runs confined, but AVC denials will not prevent the service from operating.

See https://lwn.net/Articles/303216/ for background on permissive SELinux domains.