### PR TITLE
RPM: drop /usr/lib/firewalld/services dir ownership

### DIFF
--- a/ceph-installer.spec
+++ b/ceph-installer.spec
@@ -191,7 +191,6 @@ fi
 %exclude %{_sysconfdir}/ceph-installer/config.pyc
 %exclude %{_sysconfdir}/ceph-installer/config.pyo
 %dir %attr (-, ceph-installer, ceph-installer) %{_var}/lib/ceph-installer
-%dir %attr(0750, root, root) %{_prefix}/lib/firewalld/services
 %{_prefix}/lib/firewalld/services/ceph-installer.xml
 %if 0%{?fedora} || 0%{?rhel}
 %doc selinux/*


### PR DESCRIPTION
It is not possible to install ceph-installer on RHEL 7.3 Beta:

    Transaction check error:
      file /usr/lib/firewalld/services from install of
      ceph-installer-1.0.15-1.el7scon.noarch conflicts with file from package
      firewalld-filesystem-0.4.3.2-4.el7.noarch

Version-Release number of selected component (if applicable):

    Red Hat Enterprise Linux Server release 7.3 Beta (Maipo)
    ceph-installer-1.0.15-1.el7scon.noarch
    firewalld-filesystem-0.4.3.2-4.el7.noarch

Resolves: https://bugzilla.redhat.com/1371848