### PR TITLE
add makefile for building RPMs from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ celerybeat-schedule
 
 # test db
 marinertest.db
+
+ceph-installer.spec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Makefile for constructing RPMs.
+# Try "make" (for SRPMS) or "make rpm"
+
+NAME = ceph-installer
+VERSION := $(shell PYTHONPATH=. python -c \
+             'import ceph_installer; print ceph_installer.__version__')
+COMMIT := $(shell git rev-parse HEAD)
+SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
+RELEASE := $(shell git describe --match 'v*' \
+             | sed 's/^v//' \
+             | sed 's/^[^-]*-//' \
+             | sed 's/-/./')
+ifeq ($(VERSION),$(RELEASE))
+  RELEASE = 0
+endif
+NVR := $(NAME)-$(VERSION)-$(RELEASE).el7
+
+all: srpm
+
+# Testing only
+echo:
+	echo COMMIT $(COMMIT)
+	echo VERSION $(VERSION)
+	echo RELEASE $(RELEASE)
+	echo NVR $(NVR)
+
+clean:
+	rm -rf dist/
+	rm -rf ceph-installer-$(VERSION)-$(SHORTCOMMIT).tar.gz
+	rm -rf $(NVR).src.rpm
+
+dist:
+	python setup.py sdist \
+	  && mv dist/ceph-installer-$(VERSION).tar.gz \
+          ceph-installer-$(VERSION)-$(SHORTCOMMIT).tar.gz
+
+spec:
+	sed ceph-installer.spec.in \
+	  -e 's/@COMMIT@/$(COMMIT)/' \
+	  -e 's/@VERSION@/$(VERSION)/' \
+	  -e 's/@RELEASE@/$(RELEASE)/' \
+	  > ceph-installer.spec
+
+srpm: dist spec
+	fedpkg --dist epel7 srpm
+
+rpm: dist srpm
+	mock -r ktdreyer-ceph-installer rebuild $(NVR).src.rpm
+
+.PHONY: dist rpm srpm

--- a/ceph-installer.spec.in
+++ b/ceph-installer.spec.in
@@ -1,4 +1,3 @@
-%global commitdate @COMMITDATE@
 %global commit @COMMIT@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
@@ -13,11 +12,11 @@
 
 Name:           ceph-installer
 Version:        @VERSION@
-Release:        1.%{commitdate}git%{shortcommit}%{?dist}
+Release:        @RELEASE@%{?dist}
 Summary:        A service to provision Ceph clusters
 License:        MIT
 URL:            https://github.com/ceph/ceph-installer
-Source0:        https://github.com/ceph/%{srcname}/archive/%{commit}/%{srcname}-%{version}-%{shortcommit}.tar.gz
+Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 
 BuildArch:      noarch
 
@@ -63,7 +62,7 @@ BuildRequires: python-sqlalchemy
 An HTTP API to provision and control the deployment process of Ceph clusters.
 
 %prep
-%autosetup -p1 -n %{srcname}-%{commit}
+%autosetup -p1
 
 %build
 %{__python} setup.py build


### PR DESCRIPTION
Update the RPM packaging so that we can dynamically generate RPMs with `make rpm`.

The RPM .spec file becomes a template, we get rid of the `%{commitdate}` convention and move to a `git describe` convention, similar to what ceph.git uses.

The purpose of this change is to set up a simple command to allow Jenkins to create RPMs on the fly.

For now this Makefile hardcodes an EPEL 7 mock chroot. ceph-installer fails to build in EPEL, because it lacks all the RPM dependencies. We can use a different (ceph-specific?) mock chroot when we have all the requisite RPMs in a repository somewhere.