### PR TITLE
build system fixes (mock resultdir and MANIFEST.in)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE
+include README.rst
+graft config
+graft docs
+graft firewalld
+graft selinux
+graft systemd

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ srpm: dist spec
 	fedpkg --dist epel7 srpm
 
 rpm: dist srpm
-	mock -r ktdreyer-ceph-installer rebuild $(NVR).src.rpm
+	mock -r ktdreyer-ceph-installer rebuild $(NVR).src.rpm --resultdir=.
 
 .PHONY: dist rpm srpm


### PR DESCRIPTION
The first commit updates the Makefile to write the binaries into the current working directory. This makes it a bit easier to handle the binaries in a Jenkins job.  

The second commit adds a MANIFEST.in file with the list of files we want to include in each source tarball.

At least some versions of setuptools (for example, RHEL 7's python-setuptools-0.9.8-4.el7) do not automatically include the docs, config, firewalld, selinux, or systemd directories in the source tarball during "python setup.py sdist".