### PR TITLE
rpm: mock tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ srpm: dist spec
 	fedpkg --dist epel7 srpm
 
 rpm: dist srpm
-	mock -r ktdreyer-ceph-installer rebuild $(NVR).src.rpm --resultdir=.
+	mock -r rpm/ktdreyer-ceph-installer.cfg rebuild $(NVR).src.rpm --resultdir=.
 
 .PHONY: dist rpm srpm

--- a/rpm/README.rst
+++ b/rpm/README.rst
@@ -1,0 +1,29 @@
+Building RPMs
+=============
+Here are the steps to build an RPM from a Git snapshot (your current
+``HEAD``), assuming you're on a CentOS 7 or RHEL 7 host::
+
+    # Enable EPEL
+    sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+    # Install "make" and "fedpkg":
+    sudo yum -y install make fedpkg
+
+    # Add your user account to the "mock" group.
+    sudo usermod -a -G mock $(whoami)
+
+    # Make the RPM snapshot:
+    make rpm
+
+If the build fails, try checking ``root.log`` and ``build.log``, like so::
+
+    tail -n +1 {root,build}.log
+
+
+This "rpm" directory
+====================
+This directory contains the mock configuration file for ceph-installer to build
+in a mock chroot with all its build-time dependencies.
+
+For more general information about mock, see the project home page at
+https://github.com/rpm-software-management/mock/wiki

--- a/rpm/ktdreyer-ceph-installer.cfg
+++ b/rpm/ktdreyer-ceph-installer.cfg
@@ -1,0 +1,83 @@
+config_opts['root'] = 'epel-7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '7'
+# See http://bugs.centos.org/view.php?id=7416
+config_opts['macros']['%dist'] = '.el7'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+mdpolicy=group:primary
+
+# repos
+[base]
+name=BaseOS
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[updates]
+name=updates
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[epel]
+name=epel
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[extras]
+name=extras
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[testing]
+name=epel-testing
+enabled=0
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=x86_64
+failovermethod=priority
+
+
+[local]
+name=local
+baseurl=http://kojipkgs.fedoraproject.org/repos/epel7-build/latest/x86_64/
+cost=2000
+enabled=0
+
+[epel-debug]
+name=epel-debug
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=x86_64
+failovermethod=priority
+enabled=0
+
+[ktdreyer-ceph-installer]
+name=Copr repo for ceph-installer owned by ktdreyer
+baseurl=https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+"""


### PR DESCRIPTION
Store the `ktdreyer-ceph-installer.cfg` file in source control.

`make rpm` will now use this file directly, rather than assuming the
user has installed it globally in /etc/mock.