### PR TITLE
rpm: remove ceph-ansible version pinning

### DIFF
--- a/ceph-installer.spec.in
+++ b/ceph-installer.spec.in
@@ -21,7 +21,7 @@ Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch:      noarch
 
 Requires: ansible < 2
-Requires: ceph-ansible >= 1.0.5
+Requires: ceph-ansible
 Requires: openssh
 Requires: python-celery
 Requires: python-gunicorn


### PR DESCRIPTION
We are beginning to test with newer versions of ceph-ansible. Remove the version pinning to allow us to install with newer versions (eg ceph-ansible v2).