### PR TITLE
osd: correct path to osd-configure.yml

### DIFF
--- a/ceph-installer.spec.in
+++ b/ceph-installer.spec.in
@@ -21,7 +21,7 @@ Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch:      noarch
 
 Requires: ansible < 2
-Requires: ceph-ansible
+Requires: ceph-ansible >= 2.0.0
 Requires: openssh
 Requires: python-celery
 Requires: python-gunicorn

--- a/ceph_installer/controllers/osd.py
+++ b/ceph_installer/controllers/osd.py
@@ -82,7 +82,7 @@ class OSDController(object):
         kwargs = dict(
             extra_vars=extra_vars,
             skip_tags="package-install",
-            playbook="osd-configure.yml",
+            playbook="infrastructure-playbooks/osd-configure.yml",
             verbose=verbose_ansible,
         )
         call_ansible.apply_async(


### PR DESCRIPTION
This playbook now lives in the infrastructure-playbooks directory of
ceph-ansible.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>