### PR TITLE
adds a --version argument to setup.py bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,34 +22,34 @@ version = metadata['version']
 class BumpCommand(Command):
     """ Bump the __version__ number and commit all changes. """
 
-    user_options = []
+    user_options = [('version=', 'v', 'version number to use')]
 
     def initialize_options(self):
-        pass
+        new_version = metadata['version'].split('.')
+        new_version[-1] = str(int(new_version[-1]) + 1)  # Bump the final part
+        self.version = ".".join(new_version)
 
     def finalize_options(self):
         pass
 
     def run(self):
-        version = metadata['version'].split('.')
-        version[-1] = str(int(version[-1]) + 1)  # Bump the final part
 
         try:
             print('old version: %s  new version: %s' %
-                  (metadata['version'], '.'.join(version)))
+                  (metadata['version'], self.version))
             raw_input('Press enter to confirm, or ctrl-c to exit >')
         except KeyboardInterrupt:
             raise SystemExit("\nNot proceeding")
 
         old = "__version__ = '%s'" % metadata['version']
-        new = "__version__ = '%s'" % '.'.join(version)
+        new = "__version__ = '%s'" % self.version
 
         module_file = read_module_contents()
         with open('ceph_installer/__init__.py', 'w') as fileh:
             fileh.write(module_file.replace(old, new))
 
         # Commit everything with a standard commit message
-        cmd = ['git', 'commit', '-a', '-m', 'version %s' % '.'.join(version)]
+        cmd = ['git', 'commit', '-a', '-m', 'version %s' % self.version]
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
This allows you to override the version used instead of the default
action of bumping the minor version by one.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>