### PR TITLE
adds functional tests for ceph-installer and ceph-ansible

### DIFF
--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -2,3 +2,4 @@ ubuntu-key/
 fetch/
 vagrant_ssh_config
 disk-*
+*.retry

--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -1,0 +1,4 @@
+ubuntu-key/
+fetch/
+vagrant_ssh_config
+disk-*

--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -1,0 +1,388 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+require 'time'
+VAGRANTFILE_API_VERSION = '2'
+
+DEBUG = false
+
+config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
+settings=YAML.load_file(config_file)
+
+LABEL_PREFIX   = settings['label_prefix'] ? settings['label_prefix'] + "-" : ""
+NMONS          = settings['mon_vms']
+NOSDS          = settings['osd_vms']
+NMDSS          = settings['mds_vms']
+NRGWS          = settings['rgw_vms']
+NNFSS          = settings['nfs_vms']
+RESTAPI        = settings['restapi']
+NRBD_MIRRORS   = settings['rbd_mirror_vms']
+CLIENTS        = settings['client_vms']
+NISCSI_GWS     = settings['iscsi_gw_vms']
+PUBLIC_SUBNET  = settings['public_subnet']
+CLUSTER_SUBNET = settings['cluster_subnet']
+BOX            = settings['vagrant_box']
+CLIENT_BOX     = settings['client_vagrant_box']
+BOX_URL        = settings['vagrant_box_url']
+SYNC_DIR       = settings['vagrant_sync_dir']
+MEMORY         = settings['memory']
+ETH            = settings['eth']
+USER           = settings['ssh_username']
+
+ASSIGN_STATIC_IP = settings.fetch('assign_static_ip', true)
+DISABLE_SYNCED_FOLDER = settings.fetch('vagrant_disable_synced_folder', false)
+DISK_UUID = Time.now.utc.to_i
+
+def create_vmdk(name, size)
+  dir = Pathname.new(__FILE__).expand_path.dirname
+  path = File.join(dir, '.vagrant', name + '.vmdk')
+  `vmware-vdiskmanager -c -s #{size} -t 0 -a scsi #{path} \
+   2>&1 > /dev/null` unless File.exist?(path)
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false # workaround for https://github.com/mitchellh/vagrant/issues/5048
+  config.ssh.private_key_path = settings['ssh_private_key_path']
+  config.ssh.username = USER
+
+  # Faster bootup. Disables mounting the sync folder for libvirt and virtualbox
+  if DISABLE_SYNCED_FOLDER
+    config.vm.provider :virtualbox do |v,override|
+      override.vm.synced_folder '.', SYNC_DIR, disabled: true
+    end
+    config.vm.provider :libvirt do |v,override|
+      override.vm.synced_folder '.', SYNC_DIR, disabled: true
+    end
+  end
+
+  (0..CLIENTS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}client#{i}" do |client|
+      client.vm.box = CLIENT_BOX
+      client.vm.hostname = "#{LABEL_PREFIX}ceph-client#{i}"
+      if ASSIGN_STATIC_IP
+        client.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.4#{i}"
+      end
+      # Virtualbox
+      client.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      client.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      client.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+
+      # Parallels
+      client.vm.provider "parallels" do |prl|
+        prl.name = "ceph-client#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      client.vm.provider :linode do |provider|
+        provider.label = client.vm.hostname
+      end
+    end
+  end
+
+  (0..NRGWS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}rgw#{i}" do |rgw|
+      rgw.vm.box = BOX
+      rgw.vm.box_url = BOX_URL
+      rgw.vm.hostname = "#{LABEL_PREFIX}ceph-rgw#{i}"
+      if ASSIGN_STATIC_IP
+        rgw.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.5#{i}"
+      end
+
+      # Virtualbox
+      rgw.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      rgw.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      rgw.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+
+      # Parallels
+      rgw.vm.provider "parallels" do |prl|
+        prl.name = "ceph-rgw#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      rgw.vm.provider :linode do |provider|
+        provider.label = rgw.vm.hostname
+      end
+    end
+  end
+
+  (0..NNFSS - 1).each do |i|
+    config.vm.define "nfs#{i}" do |nfs|
+      nfs.vm.box = BOX
+      nfs.vm.box_url = BOX_URL
+      nfs.vm.hostname = "ceph-nfs#{i}"
+      if ASSIGN_STATIC_IP
+        nfs.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.6#{i}"
+      end
+
+      # Virtualbox
+      nfs.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      nfs.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      nfs.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+
+      # Parallels
+      nfs.vm.provider "parallels" do |prl|
+        prl.name = "ceph-nfs#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      nfs.vm.provider :linode do |provider|
+        provider.label = nfs.vm.hostname
+      end
+    end
+  end
+
+  (0..NMDSS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}mds#{i}" do |mds|
+      mds.vm.box = BOX
+      mds.vm.box_url = BOX_URL
+      mds.vm.hostname = "#{LABEL_PREFIX}ceph-mds#{i}"
+      if ASSIGN_STATIC_IP
+        mds.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.7#{i}"
+      end
+      # Virtualbox
+      mds.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      mds.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      mds.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+      # Parallels
+      mds.vm.provider "parallels" do |prl|
+        prl.name = "ceph-mds#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      mds.vm.provider :linode do |provider|
+        provider.label = mds.vm.hostname
+      end
+    end
+  end
+
+  (0..NRBD_MIRRORS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}rbd_mirror#{i}" do |rbd_mirror|
+      rbd_mirror.vm.box = BOX
+      rbd_mirror.vm.box_url = BOX_URL
+      rbd_mirror.vm.hostname = "#{LABEL_PREFIX}ceph-rbd-mirror#{i}"
+      if ASSIGN_STATIC_IP
+        rbd_mirror.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.8#{i}"
+      end
+      # Virtualbox
+      rbd_mirror.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      rbd_mirror.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      rbd_mirror.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+      # Parallels
+      rbd_mirror.vm.provider "parallels" do |prl|
+        prl.name = "ceph-rbd-mirror#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      rbd_mirror.vm.provider :linode do |provider|
+        provider.label = rbd_mirror.vm.hostname
+      end
+    end
+  end
+
+  (0..NISCSI_GWS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}iscsi_gw#{i}" do |iscsi_gw|
+      iscsi_gw.vm.box = BOX
+      iscsi_gw.vm.box_url = BOX_URL
+      iscsi_gw.vm.hostname = "#{LABEL_PREFIX}ceph-iscsi-gw#{i}"
+      if ASSIGN_STATIC_IP
+        iscsi_gw.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.9#{i}"
+      end
+      # Virtualbox
+      iscsi_gw.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      iscsi_gw.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      iscsi_gw.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+      # Parallels
+      iscsi_gw.vm.provider "parallels" do |prl|
+        prl.name = "ceph-iscsi-gw#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      iscsi_gw.vm.provider :linode do |provider|
+        provider.label = iscsi_gw.vm.hostname
+      end
+    end
+  end
+
+  (0..NMONS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}mon#{i}" do |mon|
+      mon.vm.box = BOX
+      mon.vm.box_url = BOX_URL
+      mon.vm.hostname = "#{LABEL_PREFIX}ceph-mon#{i}"
+      if ASSIGN_STATIC_IP
+        mon.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.1#{i}"
+      end
+      # Virtualbox
+      mon.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      mon.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      mon.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+
+      # Parallels
+      mon.vm.provider "parallels" do |prl|
+        prl.name = "ceph-mon#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      mon.vm.provider :linode do |provider|
+        provider.label = mon.vm.hostname
+      end
+    end
+  end
+
+  (0..NOSDS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}osd#{i}" do |osd|
+      osd.vm.box = BOX
+      osd.vm.box_url = BOX_URL
+      osd.vm.hostname = "#{LABEL_PREFIX}ceph-osd#{i}"
+      if ASSIGN_STATIC_IP
+        osd.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.10#{i}"
+        osd.vm.network :private_network,
+          ip: "#{CLUSTER_SUBNET}.20#{i}"
+      end
+      # Virtualbox
+      osd.vm.provider :virtualbox do |vb|
+        # Create our own controller for consistency and to remove VM dependency
+        vb.customize ['storagectl', :id,
+                      '--name', 'OSD Controller',
+                      '--add', 'scsi']
+        (0..1).each do |d|
+          vb.customize ['createhd',
+                        '--filename', "disk-#{i}-#{d}",
+                        '--size', '11000'] unless File.exist?("disk-#{i}-#{d}.vdi")
+          vb.customize ['storageattach', :id,
+                        '--storagectl', 'OSD Controller',
+                        '--port', 3 + d,
+                        '--device', 0,
+                        '--type', 'hdd',
+                        '--medium', "disk-#{i}-#{d}.vdi"]
+        end
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      osd.vm.provider :vmware_fusion do |v|
+        (0..1).each do |d|
+          v.vmx["scsi0:#{d + 1}.present"] = 'TRUE'
+          v.vmx["scsi0:#{d + 1}.fileName"] =
+            create_vmdk("disk-#{i}-#{d}", '11000MB')
+        end
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      driverletters = ('a'..'z').to_a
+      osd.vm.provider :libvirt do |lv|
+        # always make /dev/sd{a/b/c} so that CI can ensure that
+        # virtualbox and libvirt will have the same devices to use for OSDs
+        (0..2).each do |d|
+          lv.storage :file, :device => "hd#{driverletters[d]}", :path => "disk-#{i}-#{d}-#{DISK_UUID}.disk", :size => '12G', :bus => "ide"
+        end
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+
+      # Parallels
+      osd.vm.provider "parallels" do |prl|
+        prl.name = "ceph-osd#{i}"
+        prl.memory = "#{MEMORY}"
+        (0..1).each do |d|
+          prl.customize ["set", :id,
+                         "--device-add",
+                         "hdd",
+                         "--iface",
+                         "sata"]
+        end
+      end
+
+      osd.vm.provider :linode do |provider|
+        provider.label = osd.vm.hostname
+      end
+
+    end
+  end
+end

--- a/tests/functional/nightly/Vagrantfile
+++ b/tests/functional/nightly/Vagrantfile
@@ -1,0 +1,1 @@
+../Vagrantfile

--- a/tests/functional/nightly/group_vars/all
+++ b/tests/functional/nightly/group_vars/all
@@ -1,7 +1,4 @@
 ---
-# this will change to master once we have stable
-# master branch built
-installer_dev_branch: functional-tests
 
 fsid: "deedcb4c-a67a-4997-93a6-92149ad2622a"
 monitor_secret: "AQA7P8dWAAAAABAAH/tbiZQn/40Z8pr959UmEA=="

--- a/tests/functional/nightly/group_vars/all
+++ b/tests/functional/nightly/group_vars/all
@@ -1,6 +1,15 @@
 ---
+# these will change to master once we have stable
+# master branches built
+installer_dev_branch: testing-rpm
+ceph_ansible_dev_branch: testing-rpm
 
-fsid: deedcb4c-a67a-4997-93a6-92149ad2622a
-monitor_secret: AQA7P8dWAAAAABAAH/tbiZQn/40Z8pr959UmEA==
+fsid: "deedcb4c-a67a-4997-93a6-92149ad2622a"
+monitor_secret: "AQA7P8dWAAAAABAAH/tbiZQn/40Z8pr959UmEA=="
 public_network: "192.168.3.0/24"
 monitor_interface: "eth1"
+monitors:
+  - host: "mon0"
+    interface: "eth1"
+devices: {"/dev/sdb": "/dev/sdc"}
+journal_size: 100

--- a/tests/functional/nightly/group_vars/all
+++ b/tests/functional/nightly/group_vars/all
@@ -1,0 +1,6 @@
+---
+
+fsid: deedcb4c-a67a-4997-93a6-92149ad2622a
+monitor_secret: AQA7P8dWAAAAABAAH/tbiZQn/40Z8pr959UmEA==
+public_network: "192.168.3.0/24"
+monitor_interface: "eth1"

--- a/tests/functional/nightly/group_vars/all
+++ b/tests/functional/nightly/group_vars/all
@@ -1,8 +1,7 @@
 ---
-# these will change to master once we have stable
-# master branches built
-installer_dev_branch: testing-rpm
-ceph_ansible_dev_branch: testing-rpm
+# this will change to master once we have stable
+# master branch built
+installer_dev_branch: functional-tests
 
 fsid: "deedcb4c-a67a-4997-93a6-92149ad2622a"
 monitor_secret: "AQA7P8dWAAAAABAAH/tbiZQn/40Z8pr959UmEA=="

--- a/tests/functional/nightly/hosts
+++ b/tests/functional/nightly/hosts
@@ -1,0 +1,12 @@
+[installer]
+client0
+
+[mons]
+mon0
+
+[osds]
+osd0
+
+[test_nodes:children]
+mons
+osds

--- a/tests/functional/nightly/hosts
+++ b/tests/functional/nightly/hosts
@@ -1,11 +1,11 @@
 [installer]
-client0
+client0 address=192.168.3.40
 
 [mons]
-mon0
+mon0 address=192.168.3.10
 
 [osds]
-osd0
+osd0 address=192.168.3.100
 
 [test_nodes:children]
 mons

--- a/tests/functional/nightly/hosts
+++ b/tests/functional/nightly/hosts
@@ -7,6 +7,9 @@ mon0 address=192.168.3.10
 [osds]
 osd0 address=192.168.3.100
 
+# This group is needed because we
+# need to register all these nodes
+# with the ceph-installer
 [test_nodes:children]
 mons
 osds

--- a/tests/functional/nightly/test.yml
+++ b/tests/functional/nightly/test.yml
@@ -21,5 +21,22 @@
       debug:
         msg: "{{ mon_install.json }}"
 
-    - name: wait for install to finish
+    - name: wait for mon install to finish
       command: "ceph-installer task --poll {{ mon_install.json['identifier'] }}"
+
+    - name: install ceph on all osds
+      uri:
+        body_format: json
+        method: POST
+        url: "{{ api_address }}/osd/install"
+        return_content: true
+        body:
+          hosts: "{{ groups['osds'] }}"
+      register: osd_install
+
+    - name: print output of osd install command
+      debug:
+        msg: "{{ osd_install.json }}"
+
+    - name: wait for osd install to finish
+      command: "ceph-installer task --poll {{ osd_install.json['identifier'] }}"

--- a/tests/functional/nightly/test.yml
+++ b/tests/functional/nightly/test.yml
@@ -1,0 +1,25 @@
+---
+- hosts: all
+  gather_facts: true
+
+- hosts: installer
+  gather_facts: false
+  vars:
+    api_address: "http://localhost:8181/api"
+  tasks:
+    - name: install ceph on all mons
+      uri:
+        body_format: json
+        method: POST
+        url: "{{ api_address }}/mon/install"
+        return_content: true
+        body:
+          hosts: "{{ groups['mons'] }}"
+      register: mon_install
+
+    - name: print output of mon install command
+      debug:
+        msg: "{{ mon_install.json }}"
+
+    - name: wait for install to finish
+      command: "ceph-installer task --poll {{ mon_install.json['identifier'] }}"

--- a/tests/functional/nightly/test.yml
+++ b/tests/functional/nightly/test.yml
@@ -24,6 +24,17 @@
     - name: wait for mon install to finish
       command: "ceph-installer task --poll {{ mon_install.json['identifier'] }}"
 
+    - name: get mon install status
+      uri:
+        method: GET
+        url: "{{ api_address }}/tasks/{{ mon_install.json['identifier'] }}"
+        return_content: true
+      register: task_result
+
+    - fail:
+        msg: "The mon install failed, see stdout: {{ task_result.json['stdout'] }}"
+      when: not task_result.json["succeeded"]
+
     - name: install ceph on all osds
       uri:
         body_format: json
@@ -40,6 +51,17 @@
 
     - name: wait for osd install to finish
       command: "ceph-installer task --poll {{ osd_install.json['identifier'] }}"
+
+    - name: get osd install status
+      uri:
+        method: GET
+        url: "{{ api_address }}/tasks/{{ osd_install.json['identifier'] }}"
+        return_content: true
+      register: task_result
+
+    - fail:
+        msg: "The osd install failed, see stdout: {{ task_result.json['stdout'] }}"
+      when: not task_result.json["succeeded"]
 
     - name: configure ceph on all mons
       uri:
@@ -62,6 +84,17 @@
     - name: wait for mon configure to finish
       command: "ceph-installer task --poll {{ mon_configure.json['identifier'] }}"
 
+    - name: get mon configure status
+      uri:
+        method: GET
+        url: "{{ api_address }}/tasks/{{ mon_configure.json['identifier'] }}"
+        return_content: true
+      register: task_result
+
+    - fail:
+        msg: "The mon configure failed, see stdout: {{ task_result.json['stdout'] }}"
+      when: not task_result.json["succeeded"]
+
     - name: configure ceph on all osds
       uri:
         body_format: json
@@ -83,3 +116,14 @@
 
     - name: wait for osd configure to finish
       command: "ceph-installer task --poll {{ osd_configure.json['identifier'] }}"
+
+    - name: get osd configure status
+      uri:
+        method: GET
+        url: "{{ api_address }}/tasks/{{ osd_configure.json['identifier'] }}"
+        return_content: true
+      register: task_result
+
+    - fail:
+        msg: "The osd configure failed, see stdout: {{ task_result.json['stdout'] }}"
+      when: not task_result.json["succeeded"]

--- a/tests/functional/nightly/test.yml
+++ b/tests/functional/nightly/test.yml
@@ -40,3 +40,24 @@
 
     - name: wait for osd install to finish
       command: "ceph-installer task --poll {{ osd_install.json['identifier'] }}"
+
+    - name: configure ceph on all mons
+      uri:
+        body_format: json
+        method: POST
+        url: "{{ api_address }}/mon/configure"
+        return_content: true
+        body:
+          host: "{{ groups['mons'][0] }}"
+          interface: "{{ monitor_interface }}"
+          fsid: "{{ fsid }}"
+          monitor_secret: "{{ monitor_secret }}"
+          public_network: "{{ public_network }}"
+      register: mon_configure
+
+    - name: print output of mon configure command
+      debug:
+        msg: "{{ mon_configure.json }}"
+
+    - name: wait for mon configure to finish
+      command: "ceph-installer task --poll {{ mon_configure.json['identifier'] }}"

--- a/tests/functional/nightly/test.yml
+++ b/tests/functional/nightly/test.yml
@@ -61,3 +61,25 @@
 
     - name: wait for mon configure to finish
       command: "ceph-installer task --poll {{ mon_configure.json['identifier'] }}"
+
+    - name: configure ceph on all osds
+      uri:
+        body_format: json
+        method: POST
+        url: "{{ api_address }}/osd/configure"
+        return_content: true
+        body:
+          host: "{{ groups['osds'][0] }}"
+          fsid: "{{ fsid }}"
+          public_network: "{{ public_network }}"
+          monitors: "{{ monitors }}"
+          journal_size: "{{ journal_size }}"
+          devices: "{{ devices }}"
+      register: osd_configure
+
+    - name: print output of osd configure command
+      debug:
+        msg: "{{ osd_configure.json }}"
+
+    - name: wait for osd configure to finish
+      command: "ceph-installer task --poll {{ osd_configure.json['identifier'] }}"

--- a/tests/functional/nightly/vagrant_variables.yml
+++ b/tests/functional/nightly/vagrant_variables.yml
@@ -1,0 +1,58 @@
+---
+
+# DEPLOY CONTAINERIZED DAEMONS
+docker: false
+
+# DEFINE THE NUMBER OF VMS TO RUN
+mon_vms: 1
+osd_vms: 1
+mds_vms: 0
+rgw_vms: 0
+nfs_vms: 0
+rbd_mirror_vms: 0
+client_vms: 1
+iscsi_gw_vms: 0
+
+# SUBNETS TO USE FOR THE VMS
+public_subnet: 192.168.3
+cluster_subnet: 192.168.4
+
+# MEMORY
+# set 1024 for CentOS
+memory: 512
+
+# Ethernet interface name
+# use eth1 for libvirt and ubuntu precise, enp0s8 for CentOS and ubuntu xenial
+eth: 'eth1'
+
+# VAGRANT BOX
+# Ceph boxes are *strongly* suggested. They are under better control and will
+# not get updated frequently unless required for build systems. These are (for
+# now):
+#
+# * ceph/ubuntu-xenial
+#
+# Ubuntu: ceph/ubuntu-xenial bento/ubuntu-16.04 or ubuntu/trusty64 or ubuntu/wily64
+# CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
+# libvirt CentOS: centos/7
+# parallels Ubuntu: parallels/ubuntu-14.04
+# Debian: deb/jessie-amd64 - be careful the storage controller is named 'SATA Controller'
+# For more boxes have a look at:
+#   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
+#   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
+vagrant_box: ceph/ubuntu-xenial
+client_vagrant_box: centos/7
+#ssh_private_key_path: "~/.ssh/id_rsa"
+# The sync directory changes based on vagrant box
+# Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
+#vagrant_sync_dir: /home/vagrant/sync
+#vagrant_sync_dir: /
+# Disables synced folder creation. Not needed for testing, will skip mounting
+# the vagrant directory on the remote box regardless of the provider.
+vagrant_disable_synced_folder: true
+# VAGRANT URL
+# This is a URL to download an image from an alternate location.  vagrant_box
+# above should be set to the filename of the image.
+# Fedora virtualbox: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+# Fedora libvirt: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-libvirt.box
+# vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box

--- a/tests/functional/playbooks/roles/installer/defaults/main.yml
+++ b/tests/functional/playbooks/roles/installer/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+installer_dev_branch: master
+installer_dev_commit: latest
+ceph_ansible_dev_branch: master
+ceph_ansible_dev_commit: latest

--- a/tests/functional/playbooks/roles/installer/tasks/main.yml
+++ b/tests/functional/playbooks/roles/installer/tasks/main.yml
@@ -17,6 +17,7 @@
     - python-devel
     - python-pip
     - python-virtualenv
+    - ansible
     - redhat-lsb-core
     - gcc
     - gcc-c++
@@ -35,10 +36,10 @@
   sudo: yes
   copy:
     content: "{{ installer_yum_repo.stdout }}"
-    dest: /etc/yum.repos.d/installer.repo
+    dest: /etc/yum.repos.d/ceph-installer.repo
     owner: root
     group: root
-    backup: yes
+    mode: 0644
 
 # we must use curl instead of ansible's uri module because SNI support in
 # Python is only available in 2.7.9 and later, and most supported distributions
@@ -54,7 +55,7 @@
     dest: /etc/yum.repos.d/ceph-ansible.repo
     owner: root
     group: root
-    backup: yes
+    mode: 0644
 
 - name: install a dev packages repo
   sudo: yes
@@ -71,12 +72,9 @@
     name: pip
     state: latest
 
-- name: install ansible globally.
+- name: purge yum cache
   sudo: yes
-  pip:
-    name: ansible 
-    state: present 
-    version: 2.2.0.0
+  command: yum clean all
 
 - name: install ceph-installer
   sudo: yes

--- a/tests/functional/playbooks/roles/installer/tasks/main.yml
+++ b/tests/functional/playbooks/roles/installer/tasks/main.yml
@@ -66,12 +66,6 @@
     group: root
     mode: 0644
 
-- name: install latest pip globally.
-  sudo: yes
-  pip:
-    name: pip
-    state: latest
-
 - name: purge yum cache
   sudo: yes
   command: yum clean all

--- a/tests/functional/playbooks/roles/installer/tasks/main.yml
+++ b/tests/functional/playbooks/roles/installer/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+
+- name: install epel
+  sudo: yes
+  yum:
+    name: epel-release
+    state: present
+    update_cache: yes
+
+- name: Install RPM requirements
+  sudo: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - git
+    - python-devel
+    - python-pip
+    - python-virtualenv
+    - redhat-lsb-core
+    - gcc
+    - gcc-c++
+    - openssl-devel
+    - libffi-devel
+  when: ansible_pkg_mgr  == "yum"
+
+# we must use curl instead of ansible's uri module because SNI support in
+# Python is only available in 2.7.9 and later, and most supported distributions
+# don't have that version, so a request to https fails.
+- name: fetch ceph-installer development repo file
+  command: 'curl -L https://shaman.ceph.com/api/repos/ceph-installer/{{ installer_dev_branch }}/{{ installer_dev_commit }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/repo?arch=noarch'
+  register: installer_yum_repo
+
+- name: add ceph-installer development repository
+  sudo: yes
+  copy:
+    content: "{{ installer_yum_repo.stdout }}"
+    dest: /etc/yum.repos.d/installer.repo
+    owner: root
+    group: root
+    backup: yes
+
+# we must use curl instead of ansible's uri module because SNI support in
+# Python is only available in 2.7.9 and later, and most supported distributions
+# don't have that version, so a request to https fails.
+- name: fetch ceph-ansible development repo file
+  command: 'curl -L https://shaman.ceph.com/api/repos/ceph-ansible/{{ ceph_ansible_dev_branch }}/{{ ceph_ansible_dev_commit }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/repo?arch=noarch'
+  register: ceph_ansible_yum_repo
+
+- name: add ceph-installer development repository
+  sudo: yes
+  copy:
+    content: "{{ ceph_ansible_yum_repo.stdout }}"
+    dest: /etc/yum.repos.d/ceph-ansible.repo
+    owner: root
+    group: root
+    backup: yes
+
+- name: install a dev packages repo
+  sudo: yes
+  template:
+    src: "templates/dev_repos.j2"
+    dest: "/etc/yum.repos.d/dev.repo"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: install latest pip globally.
+  sudo: yes
+  pip:
+    name: pip
+    state: latest
+
+- name: install ansible globally.
+  sudo: yes
+  pip:
+    name: ansible 
+    state: present 
+    version: 2.2.0.0
+
+- name: install ceph-installer
+  sudo: yes
+  yum:
+    name: ceph-installer
+    state: present
+    disable_gpg_check: true
+
+- name: ensure ceph-installer is running
+  sudo: yes
+  service:
+    name: ceph-installer
+    state: running
+    enabled: true

--- a/tests/functional/playbooks/roles/installer/templates/dev_repos.j2
+++ b/tests/functional/playbooks/roles/installer/templates/dev_repos.j2
@@ -8,9 +8,3 @@ gpgkey=https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/p
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
-
-[tmp-ktdreyer-ceph-ansible]
-name=Binaries for ceph-ansible
-baseurl=https://fedorapeople.org/~ktdreyer/ceph-installer/tmp/
-gpgcheck=0
-enabled=1

--- a/tests/functional/playbooks/roles/installer/templates/dev_repos.j2
+++ b/tests/functional/playbooks/roles/installer/templates/dev_repos.j2
@@ -1,0 +1,16 @@
+[ktdreyer-ceph-installer]
+name=Copr repo for ceph-installer owned by ktdreyer
+baseurl=https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+
+[tmp-ktdreyer-ceph-ansible]
+name=Binaries for ceph-ansible
+baseurl=https://fedorapeople.org/~ktdreyer/ceph-installer/tmp/
+gpgcheck=0
+enabled=1

--- a/tests/functional/playbooks/setup.yml
+++ b/tests/functional/playbooks/setup.yml
@@ -1,6 +1,15 @@
 ---
 - hosts: all
   gather_facts: True
+  tasks:
+    - name: write all nodes to /etc/hosts
+      sudo: yes
+      blockinfile:
+        dest: /etc/hosts
+        block: |
+          {{ hostvars[item]["address"] }} {{ item }}
+        marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item }}"
+      with_inventory_hostnames: all
 
 - hosts: installer
   gather_facts: False

--- a/tests/functional/playbooks/setup.yml
+++ b/tests/functional/playbooks/setup.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: True
+
+- hosts: installer
+  gather_facts: False
+  roles:
+    - installer

--- a/tests/functional/playbooks/setup.yml
+++ b/tests/functional/playbooks/setup.yml
@@ -6,3 +6,11 @@
   gather_facts: False
   roles:
     - installer
+
+- hosts: test_nodes
+  gather_facts: False
+  vars:
+    installer_address: "http://192.168.3.40:8181"
+  tasks:
+    - name: register the node with ceph-installer
+      shell: "curl {{ installer_address}}/setup/ | sudo bash"

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,0 +1,2 @@
+testinfra
+pytest-xdist

--- a/tests/functional/scripts/generate_ssh_config.sh
+++ b/tests/functional/scripts/generate_ssh_config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Generate a custom ssh config from Vagrant so that it can then be used by
+# ansible.cfg 
+
+path=$1
+
+if [ $# -eq 0 ]
+  then
+    echo "A path to the scenario is required as an argument and it wasn't provided"
+    exit 1
+fi
+
+cd "$path"
+vagrant ssh-config > vagrant_ssh_config

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = {ansible2.2}-{nightly}
+skipsdist = True
+
+[testenv]
+whitelist_externals =
+    vagrant
+    bash
+passenv=*
+setenv=
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ansible2.2: ANSIBLE_STDOUT_CALLBACK = debug
+deps=
+  ansible1.9: ansible==1.9.4
+  ansible2.1: ansible==2.1
+  ansible2.2: ansible==2.2
+  -r{toxinidir}/requirements.txt
+changedir=
+  nightly: {toxinidir}/nightly
+commands=
+  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/scripts/generate_ssh_config.sh {changedir}
+
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/playbooks/setup.yml
+
+#  vagrant destroy --force

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -22,5 +22,6 @@ commands=
   bash {toxinidir}/scripts/generate_ssh_config.sh {changedir}
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/playbooks/setup.yml
+  ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
 
-#  vagrant destroy --force
+  vagrant destroy --force

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -10,6 +10,7 @@ passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ansible2.2: ANSIBLE_STDOUT_CALLBACK = debug
+  ANSIBLE_RETRY_FILES_ENABLED = False
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -22,6 +22,6 @@ commands=
   bash {toxinidir}/scripts/generate_ssh_config.sh {changedir}
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/playbooks/setup.yml
-  ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
+  ansible-playbook -vvv -i {changedir}/hosts {changedir}/test.yml
 
   vagrant destroy --force


### PR DESCRIPTION
This sets up our ability to have functional tests run by CI just like we do for ceph-ansible. The test I've included here spins up three vagrant nodes, a client, a mon and an osd. On the client node it installs the latest packages from shaman for both ceph-installer and ceph-ansible and then runs tests that install and configure the mon and osd nodes.

We'd like to initially use this as a nightly scheduled run in jenkins to verify the latest builds of both projects still work nicely together.

I'd like to follow up with:

- the nightly jenkins job that will run this scenario in ceph-build
- testinfra tests to verify the cluster setup