### PR TITLE
preserve newlines in ansible output

### DIFF
--- a/ceph_installer/process.py
+++ b/ceph_installer/process.py
@@ -60,6 +60,8 @@ def run(arguments, send_input=None, **kwargs):
     """
     env = os.environ.copy()
     env["ANSIBLE_HOST_KEY_CHECKING"] = "False"
+    # preserves newlines in ansible output
+    env["ANSIBLE_STDOUT_CALLBACK"] = "debug"
     logger.info('Running command: %s' % ' '.join(arguments))
     process = subprocess.Popen(
         arguments,


### PR DESCRIPTION
This will make output from the following command much easier to read and debug:

```
ceph-installer task stdout $task_uuid
```