### PR TITLE
tests: tweaks for tox.ini

### DIFF
--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -24,6 +24,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/playbooks/setup.yml \
     --extra-vars="installer_dev_branch={env:INSTALLER_DEV_BRANCH:master} ceph_ansible_dev_branch={env:CEPH_ANSIBLE_DEV_BRANCH:master}"
-  ansible-playbook -vvv -i {changedir}/hosts {changedir}/test.yml
+  ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
 
   vagrant destroy --force

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -22,7 +22,8 @@ commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/scripts/generate_ssh_config.sh {changedir}
 
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/playbooks/setup.yml
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/playbooks/setup.yml \
+    --extra-vars="installer_dev_branch={env:INSTALLER_DEV_BRANCH:master} ceph_ansible_dev_branch={env:CEPH_ANSIBLE_DEV_BRANCH:master}"
   ansible-playbook -vvv -i {changedir}/hosts {changedir}/test.yml
 
   vagrant destroy --force


### PR DESCRIPTION
Some changes I made while integrating with jenkins:

- Allow for the ability to pass in branch names for ceph-installer and ceph-ansible.

- turn down verbosity for the tests.yml playbook