### PR TITLE
templates.py: allow centos cluster nodes

### DIFF
--- a/ceph_installer/templates.py
+++ b/ceph_installer/templates.py
@@ -12,7 +12,7 @@ if [ ! -f /etc/os-release ]; then
 fi
 
 source /etc/os-release
-if [ "$ID" != "ubuntu" ] && [ "$ID" != "rhel" ]; then
+if [ "$ID" != "ubuntu" ] && [ "$ID" != "rhel" ] && [ "$ID" != "centos" ]; then
     echo "Unsupported system detected: $ID"
     echo "will not proceed with installation"
     exit 3


### PR DESCRIPTION
Prior to this change, we restricted ceph-installer to only permit clusters on RHEL or Ubuntu. The reason for this restriction was to eliminate support requests from OSes we do not "support". 

Now that we want to run CI tests on CentOS, we should add it to the list here.