### PR TITLE
allows remote request to the /api/agent/ endpoint

### DIFF
--- a/ceph_installer/hooks.py
+++ b/ceph_installer/hooks.py
@@ -145,6 +145,8 @@ class LocalHostWritesHook(PecanHook):
 
     def before(self, state):
         local_addresses = ['127.0.0.1', '127.1.1.0', 'localhost']
+        path_whitelist = ["/api/agent/"]
         if state.request.method in ['POST', 'DELETE', 'PUT']:
             if state.request.remote_addr not in local_addresses:
-                raise JSONNonLocalRequest()
+                if state.request.path not in path_whitelist:
+                    raise JSONNonLocalRequest()

--- a/ceph_installer/tests/controllers/test_agent.py
+++ b/ceph_installer/tests/controllers/test_agent.py
@@ -20,7 +20,7 @@ class TestAgentController(object):
         assert result.json['endpoint'] == '/api/agent/'
         assert result.json['identifier'] is not None
 
-    def test_index_post_is_denied(self, session, monkeypatch):
+    def test_index_post_is_not_denied_remotely(self, session, monkeypatch):
         monkeypatch.setattr(agent.call_ansible, 'apply_async', lambda args, kwargs: None)
         data = dict(hosts=["node1"])
         result = session.app.post_json(
@@ -29,8 +29,9 @@ class TestAgentController(object):
             expect_errors=True,
             extra_environ=dict(REMOTE_ADDR='192.168.1.1')
         )
-        assert result.status_int == 403
-        assert result.json['message'] == 'this resource does not allow non-local requests'
+        assert result.status_int == 200
+        assert result.json['endpoint'] == '/api/agent/'
+        assert result.json['identifier'] is not None
 
     def test_invalid_master_value_is_detected(self, session, monkeypatch):
         data = dict(hosts=["google.com"], master=1)


### PR DESCRIPTION
This endpoint needs whitelisted as it's meant to be requested by remote
nodes during the bootstrapping process.

see: https://bugzilla.redhat.com/show_bug.cgi?id=1312443

Signed-off-by: Andrew Schoen <aschoen@redhat.com>

Resolves rhbz#1312443