### PR TITLE
tests: configure 2 OSDs, testing dedicated and collocated journals

### DIFF
--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -330,7 +330,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vb.customize ['storagectl', :id,
                       '--name', 'OSD Controller',
                       '--add', 'scsi']
-        (0..1).each do |d|
+        (0..2).each do |d|
           vb.customize ['createhd',
                         '--filename', "disk-#{i}-#{d}",
                         '--size', '11000'] unless File.exist?("disk-#{i}-#{d}.vdi")
@@ -357,9 +357,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # Libvirt
       driverletters = ('a'..'z').to_a
       osd.vm.provider :libvirt do |lv|
-        # always make /dev/sd{a/b/c} so that CI can ensure that
+        # always make /dev/sd{a/b/c/d} so that CI can ensure that
         # virtualbox and libvirt will have the same devices to use for OSDs
-        (0..2).each do |d|
+        (0..3).each do |d|
           lv.storage :file, :device => "hd#{driverletters[d]}", :path => "disk-#{i}-#{d}-#{DISK_UUID}.disk", :size => '12G', :bus => "ide"
         end
         lv.memory = MEMORY

--- a/tests/functional/nightly-centos7/group_vars/all
+++ b/tests/functional/nightly-centos7/group_vars/all
@@ -7,5 +7,6 @@ monitor_interface: "eth1"
 monitors:
   - host: "mon0"
     interface: "eth1"
-devices: {"/dev/sda": "/dev/sdb"}
+devices_dedicated_journal: {"/dev/sdb": "/dev/sdc"}
+devices_collocated_journal: ["/dev/sdd"]
 journal_size: 100

--- a/tests/functional/nightly-xenial/group_vars/all
+++ b/tests/functional/nightly-xenial/group_vars/all
@@ -7,5 +7,6 @@ monitor_interface: "eth1"
 monitors:
   - host: "mon0"
     interface: "eth1"
-devices: {"/dev/sdb": "/dev/sdc"}
+devices_dedicated_journal: {"/dev/sdb": "/dev/sdc"}
+devices_collocated_journal: ["/dev/sdd"]
 journal_size: 100

--- a/tests/functional/nightly-xenial/test.yml
+++ b/tests/functional/nightly-xenial/test.yml
@@ -95,7 +95,7 @@
         msg: "The mon configure failed, see stdout: {{ task_result.json['stdout'] }}"
       when: not task_result.json["succeeded"]
 
-    - name: configure ceph on all osds
+    - name: configure an OSD using a dedicated journal
       uri:
         body_format: json
         method: POST
@@ -107,10 +107,43 @@
           public_network: "{{ public_network }}"
           monitors: "{{ monitors }}"
           journal_size: "{{ journal_size }}"
-          devices: "{{ devices }}"
+          devices: "{{ devices_dedicated_journal }}"
       register: osd_configure
 
-    - name: print output of osd configure command
+    - name: print output of osd dedicated journal configure command
+      debug:
+        msg: "{{ osd_configure.json }}"
+
+    - name: wait for osd configure to finish
+      command: "ceph-installer task --poll {{ osd_configure.json['identifier'] }}"
+
+    - name: get osd configure status
+      uri:
+        method: GET
+        url: "{{ api_address }}/tasks/{{ osd_configure.json['identifier'] }}"
+        return_content: true
+      register: task_result
+
+    - fail:
+        msg: "The osd configure failed, see stdout: {{ task_result.json['stdout'] }}"
+      when: not task_result.json["succeeded"]
+
+    - name: configure an OSD using a collocated journal
+      uri:
+        body_format: json
+        method: POST
+        url: "{{ api_address }}/osd/configure"
+        return_content: true
+        body:
+          host: "{{ groups['osds'][0] }}"
+          fsid: "{{ fsid }}"
+          public_network: "{{ public_network }}"
+          monitors: "{{ monitors }}"
+          journal_size: "{{ journal_size }}"
+          devices: "{{ devices_collocated_journal }}"
+      register: osd_configure
+
+    - name: print output of osd collocated journal configure command
       debug:
         msg: "{{ osd_configure.json }}"
 


### PR DESCRIPTION
This configures a single OSD host with two OSDs. One that uses a dedicated journal device and the other using a collocated journal.