### PR TITLE
tests: remove duplicate logging statements

### DIFF
--- a/tests/functional/nightly-xenial/test.yml
+++ b/tests/functional/nightly-xenial/test.yml
@@ -30,6 +30,7 @@
         url: "{{ api_address }}/tasks/{{ mon_install.json['identifier'] }}"
         return_content: true
       register: task_result
+      no_log: true
 
     - fail:
         msg: "The mon install failed, see stdout: {{ task_result.json['stdout'] }}"
@@ -58,6 +59,7 @@
         url: "{{ api_address }}/tasks/{{ osd_install.json['identifier'] }}"
         return_content: true
       register: task_result
+      no_log: true
 
     - fail:
         msg: "The osd install failed, see stdout: {{ task_result.json['stdout'] }}"
@@ -90,6 +92,7 @@
         url: "{{ api_address }}/tasks/{{ mon_configure.json['identifier'] }}"
         return_content: true
       register: task_result
+      no_log: true
 
     - fail:
         msg: "The mon configure failed, see stdout: {{ task_result.json['stdout'] }}"
@@ -123,6 +126,7 @@
         url: "{{ api_address }}/tasks/{{ osd_configure.json['identifier'] }}"
         return_content: true
       register: task_result
+      no_log: true
 
     - fail:
         msg: "The osd configure failed, see stdout: {{ task_result.json['stdout'] }}"
@@ -156,6 +160,7 @@
         url: "{{ api_address }}/tasks/{{ osd_configure.json['identifier'] }}"
         return_content: true
       register: task_result
+      no_log: true
 
     - fail:
         msg: "The osd configure failed, see stdout: {{ task_result.json['stdout'] }}"


### PR DESCRIPTION
Turn logging off so these tasks don't duplicate the ansible-playbook
stdout that was just printed from the previous task. The output in these
tasks do not preserve newlines so they are not useful for
debugging anyway.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>