### PR TITLE
tests: update ansible version to 2.2.3

### DIFF
--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,4 @@
-testinfra
+# 1.6.1 fails with 'testinfra is in an unsupported or invalid wheel'
+# see https://github.com/philpep/testinfra/issues/201
+testinfra==1.6.0
 pytest-xdist

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -14,7 +14,7 @@ setenv=
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1
-  ansible2.2: ansible==2.2
+  ansible2.2: ansible==2.2.3
   -r{toxinidir}/requirements.txt
 changedir=
   nightly_xenial: {toxinidir}/nightly-xenial


### PR DESCRIPTION
This also pins testinfra to 1.6.0 as 1.6.1 is failing to install.