### PR TITLE
tests: set cpu-mode to host-passthrough for libvirt

### DIFF
--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -46,6 +46,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.private_key_path = settings['ssh_private_key_path']
   config.ssh.username = USER
 
+  # When using libvirt, avoid errors like:
+  # "CPU feature cmt not found"
+  config.vm.provider :libvirt do |lv|
+    lv.cpu_mode = 'host-passthrough'
+  end
+
   # Faster bootup. Disables mounting the sync folder for libvirt and virtualbox
   if DISABLE_SYNCED_FOLDER
     config.vm.provider :virtualbox do |v,override|


### PR DESCRIPTION
This avoids errors like the following:

Call to virDomainCreateWithFlags failed: internal error: process exited
while connecting to monitor: 2017-07-10T23:27:52.339856Z
qemu-system-x86_64: CPU feature cmt not found

Signed-off-by: Andrew Schoen <aschoen@redhat.com>