### PR TITLE
Revert "selinux: set ceph_installer_t to permissive"

### DIFF
--- a/selinux/ceph_installer.te
+++ b/selinux/ceph_installer.te
@@ -80,8 +80,6 @@ optional_policy(`
     apache_search_config(ceph_installer_t)
 ')
 
-permissive ceph_installer_t;
-
 allow ceph_installer_t ceph_installer_var_lib_t:sock_file { write create unlink link };
 allow ceph_installer_t cert_t:dir search;
 allow ceph_installer_t cert_t:file { read getattr open };


### PR DESCRIPTION
This reverts commit 00baf5bba5c8c5d0328cba9da8dbcf2bcaf5b149.

We're going to try this again.

https://bugzilla.redhat.com/1335598